### PR TITLE
[DOC] - Added description of units assumed in shuffle functions

### DIFF
--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -200,7 +200,7 @@ def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000, random_state=No
     shuffled_spikes : 2d array
         Shuffled spike times.
 		
-	Notes
+    Notes
     -----
     The input shuffle_min should always be less than the number of spikes (of input spikes).
     """

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -84,7 +84,7 @@ def shuffle_bins(spikes, bin_width_range=[50, 2000], n_shuffles=1000, random_sta
     Parameters
     ----------
     spikes : 1d array
-        Spike times.
+        Spike times, in milliseconds.
     bin_width_range : list of int
         xx
     random_state : int
@@ -189,7 +189,7 @@ def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000, random_state=No
     Parameters
     ----------
     spikes : 1d array
-        Spike times.
+        Spike times, in milliseconds.
     shuffle_min : int
         The minimum amount to rotate date, in terms of units of the spike train.
     n_shuffles : int


### PR DESCRIPTION
When working through some of the functions, we noticed and inconsistency in spike units. To help address this, this PR adds a specification that spike times should be in ms.

What's added:
* adds milliseconds to description of spikes in functions `shuffle_circular` and `shuffle_bins`.

What's next:
* we still need to update any other functions that assume milliseconds as the unit of spike.