### PR TITLE
[DOC] - Corrected units in documentation within conversions.py

### DIFF
--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -11,7 +11,7 @@ def create_spike_train(spikes):
     Parameters
     ----------
     spikes : 1d array
-        Spike times, in seconds.
+        Spike times, in milliseconds.
 
     Returns
     -------
@@ -29,7 +29,7 @@ def create_spike_train(spikes):
 
 
 def convert_train_to_times(train):
-    """Convert a spike train representation into spike times.
+    """Convert a spike train representation into spike times, in milliseconds.
 
     Parameters
     ----------
@@ -39,7 +39,7 @@ def convert_train_to_times(train):
     Returns
     -------
     spikes : 1d array
-        Spike times.
+        Spike times, in milliseconds.
     """
 
     spikes = np.where(train)[0]
@@ -62,7 +62,7 @@ def convert_isis_to_spikes(isis, offset=0, add_offset=True):
     Returns
     -------
     spikes : 1d array
-        Spike times.
+        Spike times, in milliseconds.
     """
 
     spikes = np.cumsum(isis, axis=-1)


### PR DESCRIPTION
When working through some of the functions, we noticed and inconsistency in spike units. To help address this, this PR changes a specification about the unit of spike times.

What's added:
* changes unit description of spikes from seconds to milliseconds in function `create_spike_train`.
* adds milliseconds to the description of spikes in functions `convert_train_to_times` and `convert_isis_to_spikes`.

What's next:
* we still need to update the documentation of any other functions that assume milliseconds as the unit of spike.