### PR TITLE
[DOC] - Added example for compute_occupancy

### DIFF
--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -113,8 +113,8 @@ def compute_occupancy(position, timestamps, bins, speed=None, speed_thresh=5e-6,
     -------
     2d array
         Occupancy.
-	
-	Examples
+
+    Examples
     --------
     Get occupancy for points: (x, y) =  (1, 6), (2, 7), (3, 8), (4, 9), (5, 10), (0, 0), (1, 6), (2, 6), (5, 4).
 


### PR DESCRIPTION
The functions in spatial/occupancy.py don't have examples in their docstrings yet.

What's added:
* Very simple example (in docstring) for `compute_occupancy` function, with a heatmap plot to visualize the output.

What's next:
* Change data in example to make plot more appealing.
* Keep improving the example, as right now it is very bare.
* Keep adding examples to functions that don't have them yet.