### PR TITLE
[MNT] - Added example to docstring of compute_bin_time

### DIFF
--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -73,7 +73,7 @@ def compute_bin_time(timestamps):
     1d array
         Width, in time, of each bin.
 		
-	Examples
+    Examples
     --------
     Compute times between timestamp samples:
         


### PR DESCRIPTION
The functions in spatial/occupancy.py don't have examples in their docstrings yet.

What's added:
* Very simple example (in docstring) for `compute_bin_time` function.

What's next:
* Keep adding examples to functions that don't have them yet.