### PR TITLE
[MNT] - Added example to docstring of `measures/measures.py`

### DIFF
--- a/spiketools/measures/measures.py
+++ b/spiketools/measures/measures.py
@@ -74,7 +74,7 @@ def compute_cv(isis):
     
     >>> isis = [0.3, 0.6, 0.6, 0.2, 0.7]
     >>> compute_cv(isis)
-   0.4039733214513607
+    0.4039733214513607
     """
 
     return np.std(isis) / np.mean(isis)


### PR DESCRIPTION
relates to #30 

The functions in `measures/measures.py` don't have examples in their docstrings yet.

What's added:

Very simple example (in docstring) for each function in `measures/measures.py`.

What's next:

Keep adding examples to functions that don't have them yet.