### PR TITLE
[MNT] - Added examples to `spatial/information.py`

### DIFF
--- a/spiketools/spatial/information.py
+++ b/spiketools/spatial/information.py
@@ -33,8 +33,8 @@ def compute_spatial_information_2d(spike_x, spike_y, bins, occupancy):
     >>> spike_y = [6, 7, 8, 9, 10]
     >>> bins = [2, 4]
     >>> # occupancy calculated with same bins and position, and with timestamps = np.linspace(0, 100000, position.shape[1])
-    >>> occupancy = np.array([[ 0.,  0.,  0.,  0.],
-    ...                       [ 0., 25., 25.,  0.]])
+    >>> occupancy = np.array([[0,  0,  0,  0],
+    ...                       [0, 25, 25,  0]])
     >>> compute_spatial_information_2d(spike_x, spike_y, bins, occupancy)
     -0.2643856189774725
     """
@@ -65,7 +65,7 @@ def compute_spatial_information_1d(data, occupancy, bins):
 
     Examples
     -------
-    Compute spatial information across a 2d space using spike position, occupancy, and bins:
+    Compute spatial information across a 1d space using spike position, occupancy, and bins:
     
     >>> data = [1, 2, 3, 4, 5]
     >>> occupancy = np.array([0, 25, 25, 0])


### PR DESCRIPTION
The functions in `spatial/information.py` don't have examples in their docstrings yet.
Related to #30 

What's added:
* Simple examples (in docstring) for `compute_spatial_information_2d`, and `compute_spatial_information_1d` functions.