### PR TITLE
[MNT] - RuntimeWarning not being ignored in `_compute_spatial_information`

### DIFF
--- a/spiketools/spatial/information.py
+++ b/spiketools/spatial/information.py
@@ -76,16 +76,18 @@ def _compute_spatial_information(spike_map, occupancy):
     if rate == 0.0:
         return 0.0
 
-    # Compute the occupancy probability (per bin) & normalized spiking (by occupancy)
+    # Compute the occupancy probability (per bin)
     occ_prob = occupancy / np.nansum(occupancy)
-    # Ignore RuntimeWarning
-    warnings.simplefilter("ignore", category=RuntimeWarning)
-    spike_map_norm = spike_map / occupancy
-    # Reset warnings to default
-    warnings.resetwarnings()
+    
+    # Supress RunTime warnings for invalid values that might occur in the arrays during calculations
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
 
-    # Calculate the spatial information, using a mask for nonzero values
-    nz = np.nonzero(spike_map_norm)
-    info = np.nansum(occ_prob[nz] * spike_map_norm[nz] * np.log2(spike_map_norm[nz] / rate)) / rate
+        # Calculate the normalized spiking (by occupancy)
+        spike_map_norm = spike_map / occupancy
+
+        # Calculate the spatial information, using a mask for nonzero values
+        nz = np.nonzero(spike_map_norm)
+        info = np.nansum(occ_prob[nz] * spike_map_norm[nz] * np.log2(spike_map_norm[nz] / rate)) / rate
 
     return info


### PR DESCRIPTION
The function `_compute_spatial_information` in `spatial/information.py` is set to ignore any RuntimeWarning. 
This warning is thrown, for example, depending on the occupancy input. As of now, it is not ignoring the warning.

What's added:
* One line to ignore the warning and another line to reset the warning filters.
* Removed previous warning handling.

What's next:
* Maybe put a more specific filter for the warning.