### PR TITLE
[ENH] - Added test function for `_compute_spatial_information`

### DIFF
--- a/spiketools/tests/spatial/test_information.py
+++ b/spiketools/tests/spatial/test_information.py
@@ -1,6 +1,7 @@
 """Tests for spiketools.spatial.information"""
 
 from spiketools.spatial.information import *
+from spiketools.spatial.information import _compute_spatial_information
 
 ###################################################################################################
 ###################################################################################################
@@ -51,4 +52,23 @@ def test_compute_spatial_information_1d():
     assert spatial_information_1d_1 > spatial_information_1d_3
 
 def test_compute_spatial_information():
-    pass
+    
+    # 2d CASE:
+    spike_x = [1, 2, 3, 4, 5]
+    spike_y = [6, 7, 8, 9, 10]
+    bins = [2, 4]
+    spike_map_2d = np.histogram2d(spike_x, spike_y, bins=bins)[0]
+    occupancy_2d = np.array([[1,   1,   1, 1],
+                             [1, 250, 250, 1]])
+    spatial_information_2d_1 = _compute_spatial_information(spike_map_2d, occupancy_2d)
+
+    # 1d CASE:
+    data = [1, 2, 3, 4, 5]
+    bins = [2, 4]
+    spike_map_1d = np.histogram(data, bins=bins)[0]
+    occupancy_1d = np.array([1, 250, 250, 1])
+    spatial_information_1d_1 = _compute_spatial_information(spike_map_1d, occupancy_1d)
+    
+    # dimension check: each of the calculated spatial informations should have a single output.
+    # also checks that function behaves well with different input dimensions.
+    assert np.array([spatial_information_2d_1, spatial_information_1d_1]).shape[0] == 2


### PR DESCRIPTION
In the process of creating test functions for other functions that don't yet have one. Related to issue #34 

What's added:
* adds `test_compute_spatial_information` function for `_compute_spatial_information` within `spatial\information.py`.
