### PR TITLE
[MNT] - Added examples to `sim/prob.py`

### DIFF
--- a/spiketools/sim/prob.py
+++ b/spiketools/sim/prob.py
@@ -21,11 +21,11 @@ def sim_spiketrain_prob(p_spiking, n_samples=None):
         Simulated spike train.
 	
     Notes
-    -------
+    -----
     n_samples is only used if p_spiking is a float, otherwise n_samples is just the length of p_spiking.
 
     Examples
-    -------
+    --------
     Simulate spike train of size n_samples, based on a probability of spiking per sample.
 
     >>> p_spiking = 0.3


### PR DESCRIPTION
Related to #30.

What's added:
* Examples (in docstring) for `sim_spiketrain_prob` function (`sim/prob.py`).
