### PR TITLE
[MNT] - Swapped test functions from `sim/test_prob.py` and `sim/test_dist.py`

### DIFF
--- a/spiketools/tests/sim/test_dist.py
+++ b/spiketools/tests/sim/test_dist.py
@@ -5,5 +5,8 @@ from spiketools.sim.dist import *
 ###################################################################################################
 ###################################################################################################
 
-def test_sim_spiketrain_prob():
+def test_sim_spiketrain_binom():
+    pass
+
+def test_sim_spiketrain_poisson():
     pass

--- a/spiketools/tests/sim/test_prob.py
+++ b/spiketools/tests/sim/test_prob.py
@@ -5,8 +5,5 @@ from spiketools.sim.prob import *
 ###################################################################################################
 ###################################################################################################
 
-def test_sim_spiketrain_binom():
-    pass
-
-def test_sim_spiketrain_poisson():
+def test_sim_spiketrain_prob():
     pass


### PR DESCRIPTION
When creating a test for `sim_spiketrain_prob`, noticed that the functions in the files `sim/test_prob.py` and `sim/test_dist.py` were swapped.
What's changed:
* Un-swapped test functions from `sim/test_prob.py` and `sim/test_dist.py`. Now they correspond to functions in `sim/prob.py` and `sim/dist.py` respectively.