### PR TITLE
[MNT] - Added examples to `measures/conversions.py`

### DIFF
--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -53,7 +53,7 @@ def convert_train_to_times(train):
     
     >>> spike_train = [0,0,0,1,0,1,0,0,1,1,1,1,0,1]
     >>> convert_train_to_times(spike_train)
-    [4, 6, 9, 10, 11, 12, 14]
+    array([ 4,  6,  9, 10, 11, 12, 14])
     """
 
     spikes = np.where(train)[0]


### PR DESCRIPTION
This relates to #30

The functions in measures/conversions.py don't have examples in their docstrings yet.

What's added:

- Simple examples (in docstring) for `create_spike_train`, `convert_train_to_times`, and `convert_isis_to_spikes` functions.