### PR TITLE
[ENH] - TypeError in `sim/utils.py`

### DIFF
--- a/spiketools/sim/utils.py
+++ b/spiketools/sim/utils.py
@@ -12,7 +12,7 @@ def refractory(spikes, refractory_time, fs):
     ----------
     spikes : 1d array
         Spike train.
-    refractory : float
+    refractory_time : float
         The duration of the refractory period, after a spike, in seconds.
     fs : float
         The sampling rate.


### PR DESCRIPTION
Hey @TomDonoghue , I noticed that this refractory function in sim/utils.py raises a TypeError because this function shares the same name with one of its input arguments refractory period. To fix this, I changed the name of the input argument from refractory to refractory_time.

This may need to be merged before merging its test function (will fail otherwise).