### PR TITLE
[MNT] - Added Examples to `sim/dist.py`

### DIFF
--- a/spiketools/sim/dist.py
+++ b/spiketools/sim/dist.py
@@ -69,7 +69,7 @@ def sim_spiketrain_poisson(rate, n_samples, fs, bias=0):
     --------
     Simulate a spike train from a Poisson distribution.
     
-    >>> sim_spiketrain_poisson(0.4, 10, 1000, bias=0)
+    >>> spikes = sim_spiketrain_poisson(0.4, 10, 1000, bias=0)
     """
 
     spikes = np.zeros(n_samples)


### PR DESCRIPTION
Related to #30.

What's added:

Examples (in docstring) for `sim_spiketrain_binom` and `sim_spiketrain_poisson` functions.