### PR TITLE
[BUG] - Issue with `create_spike_train`

### DIFF
--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -27,9 +27,9 @@ def create_spike_train(spikes):
     array([0., 0., 0., ..., 0., 0., 0.])
     """
 
-    spike_train = np.zeros(np.ceil(spikes[-1]).astype(int))
+    spike_train = np.zeros((np.ceil(spikes[-1]) + 1).astype(int))
 
-    inds = [int(ind) for ind in spikes if ind < spike_train.shape[-1]]
+    inds = [int(ind) for ind in spikes if ind <= spike_train.shape[-1]]
 
     spike_train[inds] = 1
 

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -24,7 +24,7 @@ def create_spike_train(spikes):
     
     >>> spikes = [250, 500, 750, 1000, 1250, 1500]
     >>> create_spike_train(spikes)
-    array([0., 0., 0., ..., 0., 0., 0.])
+    array([0., 0., 0., ..., 0., 0., 1.])
     """
 
     spike_train = np.zeros((np.ceil(spikes[-1]) + 1).astype(int))


### PR DESCRIPTION
Addressing #75 
There is an issue with the `create_spike_train` function, in that it sometimes ignores the last spike time. 
This affects `shuffle_circular` and `shuffle_bins` functions.
This seems to be happening because the pre-allocated space for the output (`spike_train`) in the `create_spike_train` is too small by one. Additionally, when setting `1` to the correct `spike_train` positions, the last one is missing.

What's changed:
* Pre-allocated space for the output (`spike_train`) in the `create_spike_train` is increased by one. 
* Last spike time included in `spike_train`.