### PR TITLE
[MNT] - Added examples to `sim/utils.py`

### DIFF
--- a/spiketools/sim/utils.py
+++ b/spiketools/sim/utils.py
@@ -23,7 +23,6 @@ def refractory(spikes, refractory_time, fs):
 
     Examples
     --------
-
     Apply a 0.3 seconds refractory period to a binary spike train with 1000 Hz sampling rate.
 
     >>> spikes = np.array([0,1,1,1,0,1,1,1,0,1,1,1,1,0,1,1,0,1,0,])

--- a/spiketools/sim/utils.py
+++ b/spiketools/sim/utils.py
@@ -23,7 +23,7 @@ def refractory(spikes, refractory_time, fs):
 
     Examples
     --------
-    Apply a 0.3 seconds refractory period to a binary spike train with 1000 Hz sampling rate.
+    Apply a 0.003 seconds refractory period to a binary spike train with 1000 Hz sampling rate.
 
     >>> spikes = np.array([0,1,1,1,0,1,1,1,0,1,1,1,1,0,1,1,0,1,0,])
     >>> refractory(spikes, 0.003, 1000)

--- a/spiketools/sim/utils.py
+++ b/spiketools/sim/utils.py
@@ -3,6 +3,7 @@
 ###################################################################################################
 ###################################################################################################
 
+
 def refractory(spikes, refractory_time, fs):
     """Apply a refractory period to a simulated spike train.
 
@@ -19,6 +20,15 @@ def refractory(spikes, refractory_time, fs):
     -------
     spikes : 1d array
         Spike train, with refractory period constraint applied.
+
+    Examples
+    --------
+
+    Apply a 0.3 seconds refractory period to a binary spike train with 1000 Hz sampling rate.
+
+    >>> spikes = np.array([0,1,1,1,0,1,1,1,0,1,1,1,1,0,1,1,0,1,0,])
+    >>> refractory(spikes, 0.003, 1000)
+    array([0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0])
     """
 
     ref_len = int(refractory_time * fs)


### PR DESCRIPTION
The functions in `sim/utils.py` don't have examples in their docstrings yet.

What's added:

Simple examples (in docstring) for `refractory` function.