### PR TITLE
[ENH] - 1d and 2d function compatibility

### DIFF
--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -191,7 +191,7 @@ def compute_occupancy(position, timestamps, bins, speed=None, speed_thresh=5e-6,
     (x, y) = (1.5, 6.5), (2.5, 7.5), (3.5, 8.5), (5, 9).
 
     >>> position = np.array([[1.5, 2.5, 3.5, 5], [6.5, 7.5, 8.5, 9]])
-    >>> timestamps = np.linspace(0, 1000, position.shape[1])
+    >>> timestamps = np.linspace(0, 1, position.shape[1])
     >>> bins = [5, 5]
     >>> occ = compute_occupancy(position, timestamps, bins)
 
@@ -199,10 +199,10 @@ def compute_occupancy(position, timestamps, bins, speed=None, speed_thresh=5e-6,
     x = 1.5, 2.5, 3.5, 5.
 
     >>> position = np.array([1.5, 2.5, 3.5, 5])
-    >>> timestamps = np.linspace(0, 1000, position.shape[0])
+    >>> timestamps = np.linspace(0, 1, position.shape[0])
     >>> bins = [4]
     >>> compute_occupancy(position, timestamps, bins)
-    array([333.33333333, 333.33333333, 333.33333333, 0.        ])
+    array([0.33333333, 0.33333333, 0.33333333, 0.        ])
     """
 
     # 2d case

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -11,9 +11,9 @@ def compute_spatial_bin_edges(position, bins, area_range=None):
 
     Parameters
     ----------
-    position : 2d array
-        Position values across a 2D space.
-    bins : list of [int, int]
+    position : 1d or 2d array
+        Position values across a 1D or 2D space.
+    bins : list of [int] or [int, int]
         The number of bins to divide up the space, defined as [number of x_bins, number of y_bins].
     area_range : list of list, optional
         Edges of the area to bin, defined as [[x_min, x_max], [y_min, y_max]].
@@ -21,8 +21,10 @@ def compute_spatial_bin_edges(position, bins, area_range=None):
 
     Returns
     -------
-    x_edges, y_edges : 1d array
+    x_edges : 1d array
         Edge definitions for the spatial binning.
+    y_edges : 1d array
+        Edge definitions for the spatial binning. Only returned in 2D case.
 
     Examples
     --------
@@ -33,31 +35,51 @@ def compute_spatial_bin_edges(position, bins, area_range=None):
     >>> bins = [5, 4]
     >>> compute_spatial_bin_edges(position, bins)
     (array([1. , 1.8, 2.6, 3.4, 4.2, 5. ]), array([ 6.,  7.,  8.,  9., 10.]))
+
+	Compute bin edges for an example 1d space, with positions 1 through 5.
+    >>> position = np.array([1, 2, 3, 4, 5])
+    >>> bins = [5]
+    >>> compute_spatial_bin_edges(position, bins)
+    array([1. , 1.8, 2.6, 3.4, 4.2, 5. ])
     """
 
-    _, x_edges, y_edges = np.histogram2d(position[0, :], position[1, :],
+    # 2d case
+    if (len(bins) == 2):
+        _, x_edges, y_edges = np.histogram2d(position[0, :], position[1, :],
                                          bins=bins, range=area_range)
 
-    return x_edges, y_edges
+        return x_edges, y_edges
+
+    # 1d case
+    else:
+        _, x_edges = np.histogram(position, bins=bins[0], range=area_range)
+        
+        return x_edges
 
 
-def compute_spatial_bin_assignment(position, x_edges, y_edges, include_edge=True):
+def compute_spatial_bin_assignment(position, x_edges, y_edges=None, include_edge=True):
     """Compute spatial bin assignment.
 
     Parameters
     ----------
-    position : 2d array
-        Position information across a 2D space.
-    x_edges, y_edges : 1d array
+    position : 1d or 2d array
+        Position information across a 1D or 2D space.
+    x_edges : 1d array
         Edge definitions for the spatial binning.
         Values within the arrays should be monotonically increasing.
+    y_edges : 1d array, optional, default: None
+        Edge definitions for the spatial binning.
+        Values within the arrays should be monotonically increasing.
+        Used in 2d case only.
     include_edge : bool, optional, default: True
         Whether to include positions on the edge into the bin.
 
     Returns
     -------
-    x_bins, y_bins : 1d array
+    x_bins : 1d array
         Bin assignments for each position.
+    y_bins : 1d array
+        Bin assignments for each position, only returned in 2D case.
 
     Notes
     -----
@@ -75,17 +97,35 @@ def compute_spatial_bin_assignment(position, x_edges, y_edges, include_edge=True
     >>> position = np.array([[1.5, 2.5, 3.5, 5], [6.5, 7.5, 8.5, 9]])
     >>> x_edges = np.array([1, 2, 3, 4, 5])
     >>> y_edges = np.array([6, 7, 8, 9, 10])
-    >>> x_bins, y_bins = compute_spatial_bin_assignment(position, x_edges, y_edges)
+    >>> compute_spatial_bin_assignment(position, x_edges, y_edges)
+    (array([1, 2, 3, 4], dtype=int64), array([1, 2, 3, 4], dtype=int64))
+
+    Compute bin assignment of 1d position, given existing 1d spatial bins:
+    >>> position = np.array([1.5, 2.5, 3.5, 5])
+    >>> x_edges = np.array([1, 2, 3, 4, 5])
+    >>> compute_spatial_bin_assignment(position, x_edges)
+    array([1, 2, 3, 4], dtype=int64)
     """
 
-    x_bins = np.digitize(position[0, :], x_edges, right=False)
-    y_bins = np.digitize(position[1, :], y_edges, right=False)
+    # 2d case
+    if (y_edges is not None):
+        x_bins = np.digitize(position[0, :], x_edges, right=False)
+        y_bins = np.digitize(position[1, :], y_edges, right=False)
 
-    if include_edge:
-        x_bins = _include_bin_edge(position[0, :], x_bins, x_edges, side='left')
-        y_bins = _include_bin_edge(position[1, :], y_bins, y_edges, side='left')
+        if include_edge:
+            x_bins = _include_bin_edge(position[0, :], x_bins, x_edges, side='left')
+            y_bins = _include_bin_edge(position[1, :], y_bins, y_edges, side='left')
 
-    return x_bins, y_bins
+        return x_bins, y_bins
+
+    # 1d case
+    else:
+        x_bins = np.digitize(position, x_edges, right=False)
+
+        if include_edge:
+            x_bins = _include_bin_edge(position, x_bins, x_edges, side='left')
+
+        return x_bins
 
 
 def compute_bin_time(timestamps):
@@ -119,8 +159,8 @@ def compute_occupancy(position, timestamps, bins, speed=None, speed_thresh=5e-6,
 
     Parameters
     ----------
-    position : 2d array
-        Position information across a 2D space.
+    position : 1d or 2d array
+        Position information across a 1D or 2D space.
     timestamps : 1d array
         Timestamps.
     bins : list of int
@@ -142,40 +182,70 @@ def compute_occupancy(position, timestamps, bins, speed=None, speed_thresh=5e-6,
 
     Returns
     -------
-    2d array
+    occ : 1d or 2d array
         Occupancy.
 
     Examples
     --------
-    Get occupancy for points:
-    (x, y) =  (1, 6), (2, 7), (3, 8), (4, 9), (5, 10), (0, 0), (1, 6), (2, 6), (5, 4).
+    Get 2D occupancy for positions:
+    (x, y) = (1.5, 6.5), (2.5, 7.5), (3.5, 8.5), (5, 9).
 
-    >>> position = np.array([[1, 2, 3, 4, 5, 0, 1, 2, 5], [6, 7, 8, 9, 10, 0, 6, 6, 4]])
-    >>> timestamps = np.linspace(0, 30, position.shape[1])
+    >>> position = np.array([[1.5, 2.5, 3.5, 5], [6.5, 7.5, 8.5, 9]])
+    >>> timestamps = np.linspace(0, 1000, position.shape[1])
     >>> bins = [5, 5]
     >>> occ = compute_occupancy(position, timestamps, bins)
+
+    Get 1D occupancy for positions:
+    x = 1.5, 2.5, 3.5, 5.
+
+    >>> position = np.array([1.5, 2.5, 3.5, 5])
+    >>> timestamps = np.linspace(0, 1000, position.shape[0])
+    >>> bins = [4]
+    >>> compute_occupancy(position, timestamps, bins)
+    array([0.33333333, 0.33333333, 0.33333333, 0.        ])
     """
 
-    # Compute spatial bins & binning
-    x_edges, y_edges = compute_spatial_bin_edges(position, bins, area_range)
-    x_bins, y_bins = compute_spatial_bin_assignment(position, x_edges, y_edges)
-    bin_time = compute_bin_time(timestamps)
+    # 2d case
+    if (len(bins) == 2):
+        # Compute spatial bins & binning
+        x_edges, y_edges = compute_spatial_bin_edges(position, bins, area_range)
+        x_bins, y_bins = compute_spatial_bin_assignment(position, x_edges, y_edges)
+        bin_time = compute_bin_time(timestamps)
 
-    # Make a temporary pandas dataframe
-    df = pd.DataFrame({
-        'xbins' : pd.Categorical(x_bins, categories=list(range(1, bins[0] + 1)), ordered=True),
-        'ybins' : pd.Categorical(y_bins, categories=list(range(1, bins[1] + 1)), ordered=True),
-        'bin_time' : bin_time})
+        # Make a temporary pandas dataframe
+        df = pd.DataFrame({
+            'xbins' : pd.Categorical(x_bins, categories=list(range(1, bins[0] + 1)), ordered=True),
+            'ybins' : pd.Categorical(y_bins, categories=list(range(1, bins[1] + 1)), ordered=True),
+            'bin_time' : bin_time})
 
-    # Apply the speed threshold (dropping slow / stationary timepoints)
-    if np.any(speed):
-        df = df[speed > speed_thresh]
+        # Apply the speed threshold (dropping slow / stationary timepoints)
+        if np.any(speed):
+            df = df[speed > speed_thresh]
 
-    # Group each position into a spatial bin, summing total time spent there
-    df = df.groupby(['xbins', 'ybins'])['bin_time'].sum()
+        # Group each position into a spatial bin, summing total time spent there
+        df = df.groupby(['xbins', 'ybins'])['bin_time'].sum()
+
+    # 1d case
+    else:
+        # Compute spatial bins & binning
+        x_edges = compute_spatial_bin_edges(position, bins, area_range)
+        x_bins = compute_spatial_bin_assignment(position, x_edges)
+        bin_time = compute_bin_time(timestamps)
+
+        # Make a temporary pandas dataframe
+        df = pd.DataFrame({
+            'xbins' : pd.Categorical(x_bins, categories=list(range(1, bins[0] + 1)), ordered=True),
+            'bin_time' : bin_time})
+
+        # Apply the speed threshold (dropping slow / stationary timepoints)
+        if np.any(speed):
+            df = df[speed > speed_thresh]
+
+        # Group each position into a spatial bin, summing total time spent there
+        df = df.groupby(['xbins'])['bin_time'].sum()
 
     # Extract and re-organize occupancy into 2d array
-    occ = np.squeeze(df.values.reshape(*bins, -1))
+    occ = np.squeeze(df.values.reshape(*bins, -1)) / 1000
 
     if minimum:
         occ[occ < minimum] = 0.

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -202,7 +202,7 @@ def compute_occupancy(position, timestamps, bins, speed=None, speed_thresh=5e-6,
     >>> timestamps = np.linspace(0, 1000, position.shape[0])
     >>> bins = [4]
     >>> compute_occupancy(position, timestamps, bins)
-    array([0.33333333, 0.33333333, 0.33333333, 0.        ])
+    array([333.33333333, 333.33333333, 333.33333333, 0.        ])
     """
 
     # 2d case
@@ -245,7 +245,7 @@ def compute_occupancy(position, timestamps, bins, speed=None, speed_thresh=5e-6,
         df = df.groupby(['xbins'])['bin_time'].sum()
 
     # Extract and re-organize occupancy into 2d array
-    occ = np.squeeze(df.values.reshape(*bins, -1)) / 1000
+    occ = np.squeeze(df.values.reshape(*bins, -1))
 
     if minimum:
         occ[occ < minimum] = 0.

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -98,13 +98,13 @@ def compute_spatial_bin_assignment(position, x_edges, y_edges=None, include_edge
     >>> x_edges = np.array([1, 2, 3, 4, 5])
     >>> y_edges = np.array([6, 7, 8, 9, 10])
     >>> compute_spatial_bin_assignment(position, x_edges, y_edges)
-    (array([1, 2, 3, 4], dtype=int64), array([1, 2, 3, 4], dtype=int64))
+    (array([1, 2, 3, 4]), array([1, 2, 3, 4]))
 
     Compute bin assignment of 1d position, given existing 1d spatial bins:
     >>> position = np.array([1.5, 2.5, 3.5, 5])
     >>> x_edges = np.array([1, 2, 3, 4, 5])
     >>> compute_spatial_bin_assignment(position, x_edges)
-    array([1, 2, 3, 4], dtype=int64)
+    array([1, 2, 3, 4])
     """
 
     # 2d case

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -5,12 +5,12 @@ import numpy as np
 ###################################################################################################
 ###################################################################################################
 
-def get_pos_ranges(positions):
+def get_pos_ranges(position):
     """Compute the range of positions.
 
     Parameters
     ----------
-    positions : 1d or 2d array
+    position : 1d or 2d array
         Position data.
 
     Returns
@@ -27,7 +27,7 @@ def get_pos_ranges(positions):
     >>> get_pos_ranges(position)
     [[1.5, 5.0], [6.5, 9.0]]
 
-	Get 1D position ranges for:
+    Get 1D position ranges for:
     x = 1.5, 2.5, 3.5, 5.
 
     >>> position = np.array([1.5, 2.5, 3.5, 5])
@@ -37,14 +37,15 @@ def get_pos_ranges(positions):
 
     ranges = []
 
-    # 2+d case
-    if (len(positions.shape) > 1):
-        for dim in range(positions.shape[0]):
-            ranges.append([np.min(positions[dim, :]), np.max(positions[dim, :])])
+    if position.ndim == 1:
+        ranges.append([np.min(position[:]), np.max(position[:])])
 
-    # 1d case
+    elif position.ndim == 2:
+        for dim in range(position.shape[0]):
+            ranges.append([np.min(position[dim, :]), np.max(position[dim, :])])
+
     else:
-        ranges.append([np.min(positions[:]), np.max(positions[:])])
+        raise ValueError('Position input should be 1d or 2d.')
 
     return ranges
 

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -10,18 +10,41 @@ def get_pos_ranges(positions):
 
     Parameters
     ----------
-    positions : 2d array
+    positions : 1d or 2d array
         Position data.
 
     Returns
     -------
     ranges : list of list of float
         Ranges for each dimension in the spatial data.
+
+    Examples
+    --------
+    Get 2D position ranges for:
+    (x, y) = (1.5, 6.5), (2.5, 7.5), (3.5, 8.5), (5, 9).
+
+    >>> position = np.array([[1.5, 2.5, 3.5, 5], [6.5, 7.5, 8.5, 9]])
+    >>> get_pos_ranges(position)
+    [[1.5, 5.0], [6.5, 9.0]]
+
+	Get 1D position ranges for:
+    x = 1.5, 2.5, 3.5, 5.
+
+    >>> position = np.array([1.5, 2.5, 3.5, 5])
+    >>> get_pos_ranges(position)
+    [[1.5, 5.0]]
     """
 
     ranges = []
-    for dim in range(positions.shape[0]):
-        ranges.append([np.min(positions[dim, :]), np.max(positions[dim, :])])
+
+    # 2+d case
+    if (len(positions.shape) > 1):
+        for dim in range(positions.shape[0]):
+            ranges.append([np.min(positions[dim, :]), np.max(positions[dim, :])])
+
+    # 1d case
+    else:
+        ranges.append([np.min(positions[:]), np.max(positions[:])])
 
     return ranges
 


### PR DESCRIPTION
Added 1d and 2d cases for functions within `spatial\occupancy.py` and `spatial\utils.py`.
The goal is to reduce unnecessary overlapping code.
Addressing #101.

Functions that changed:
* `compute_spatial_bin_edges`
* `compute_spatial_bin_assignment`
* `compute_occupancy` 
* `get_pos_ranges` (also added example/docstring test for this one)