### PR TITLE
[ENH] - Update Shuffle Circular-Bins

### DIFF
--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -76,14 +76,14 @@ def shuffle_isis(spikes, n_shuffles=1000):
 
 
 def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000):
-    """Shuffle data with a circular shuffle of the spike train.
+    """Shuffle data with circular shuffles of randomly sized bins of the spike train.
 
     Parameters
     ----------
     spikes : 1d array
         Spike times, in seconds.
-    bin_width_range : list of [int, int], optional, default : [.5, 7]
-        Range of bin widths in seconds to shuffle by.
+    bin_width_range : list of [float, float], optional, default : [.5, 7]
+        Range of bin widths in seconds from which bin sizes are randomly selected.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
 

--- a/spiketools/tests/conftest.py
+++ b/spiketools/tests/conftest.py
@@ -36,7 +36,8 @@ def check_dir():
 @pytest.fixture(scope='session')
 def tspikes():
 
-    yield np.array([0.5, 1.5, 2., 2.5, 3., 3.75, 4.])
+    yield np.array([0.5, 1.5, 2., 2.5, 3., 3.75, 4., 4.25, 5., 5.5, 
+                    5.75, 6., 7., 7.5, 8.])
 
 
 @pytest.fixture(scope='session')

--- a/spiketools/tests/measures/test_measures.py
+++ b/spiketools/tests/measures/test_measures.py
@@ -19,7 +19,8 @@ def test_compute_isis(tspikes):
     isis = compute_isis(tspikes)
     assert isinstance(isis, np.ndarray)
     assert isis.shape[-1] + 1 == tspikes.shape[-1]
-    assert np.allclose(isis, np.array([1.0, 0.5, 0.5, 0.5, 0.75, 0.25]))
+    assert np.allclose(isis, np.array([1.0, 0.5, 0.5, 0.5, 0.75, 0.25, 0.25,
+                                       0.75, 0.5, 0.25, 0.25, 1.0, 0.5, 0.5]))
     assert sum(isis < 0) == 0
 
 def test_compute_cv():


### PR DESCRIPTION
Updating `shuffle_bins` to prevent broken case scenarios.
Addressing #107.

What's changed:
* Units: milliseconds -> seconds
* Argument default: `bin_width_range=[50, 2000]` -> `bin_width_range=[.5, 7]`

What's added:
* More description for `bin_width_range` argument in the Notes of the docstring.
* New spikes to `tspikes()` (`conftest.py`) due to the new maximum in `bin_width_range=[.5, 7]` default.
* New ISIs to `test_compute_isis(tspikes)` to accommodate new spikes in `tspikes`.