### PR TITLE
[ENH] - Add `plot_trial_heatmaps` function

### DIFF
--- a/spiketools/modutils/functions.py
+++ b/spiketools/modutils/functions.py
@@ -1,0 +1,25 @@
+"""Module level utilities for working with functions."""
+
+from inspect import signature
+
+###################################################################################################
+###################################################################################################
+
+def get_function_parameters(function):
+    """Get a list of input parameters for a function.
+
+    Parameters
+    ----------
+    function : callable
+        A function to get the parameters from.
+
+    Returns
+    -------
+    parameters : list of str
+        Names of the input parameters to the given function.
+    """
+
+    sig = signature(function)
+    parameters = list(sig.parameters.keys())
+
+    return parameters

--- a/spiketools/plts/spatial.py
+++ b/spiketools/plts/spatial.py
@@ -6,9 +6,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from spiketools.utils.data import smooth_data, compute_range
+from spiketools.modutils.functions import get_function_parameters
 from spiketools.plts.annotate import _add_dots
 from spiketools.plts.settings import DEFAULT_COLORS
-from spiketools.plts.utils import check_ax, savefig, set_plt_kwargs
+from spiketools.plts.utils import check_ax, savefig, set_plt_kwargs, make_axes
 
 ###################################################################################################
 ###################################################################################################
@@ -176,6 +177,26 @@ def plot_heatmap(data, transpose=False, smooth=False, smoothing_kernel=1.5,
     if cbar:
         colorbar = plt.colorbar(im)
         colorbar.outline.set_visible(False)
+
+
+@savefig
+def plot_trial_heatmaps(trial_data, **plt_kwargs):
+    """Plot spatial heat maps for a set of trials.
+
+    Parameters
+    ----------
+    trial_data : 3d array
+        Spatially binned spike activity, per trial, with shape of [n_trials, n_xbins, n_ybins].
+    plt_kwargs
+        Additional arguments to pass into the plot function.
+        This can include argument into `make_axes`, which initialize the set of axes.
+    """
+
+    axis_kwargs = {key : plt_kwargs.pop(key) \
+        for key in get_function_parameters(make_axes) if key in plt_kwargs}
+    axes = make_axes(trial_data.shape[0], **axis_kwargs)
+    for data, ax in zip(trial_data, axes):
+        plot_heatmap(data, **plt_kwargs, ax=ax)
 
 
 def create_heat_title(label, data, stat=None, p_val=None):

--- a/spiketools/tests/modutils/test_functions.py
+++ b/spiketools/tests/modutils/test_functions.py
@@ -1,0 +1,15 @@
+"""Tests for spiketools.modutils.functions."""
+
+from spiketools.modutils.functions import *
+
+###################################################################################################
+###################################################################################################
+
+def test_get_function_parameters():
+
+    def func(a, b, c=None):
+        pass
+
+    parameters = get_function_parameters(func)
+    assert isinstance(parameters, list)
+    assert parameters == ['a', 'b', 'c']

--- a/spiketools/tests/plts/test_spatial.py
+++ b/spiketools/tests/plts/test_spatial.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from spiketools.tests.tutils import plot_test
+from spiketools.tests.tutils import plot_test, fig_test
 from spiketools.tests.tsettings import TEST_PLOTS_PATH
 
 from spiketools.plts.spatial import *
@@ -63,6 +63,15 @@ def test_plot_heatmap():
     data1d = np.array([0., 1., 2., 0., 2., 1.])
     plot_heatmap(data1d,
                  file_path=TEST_PLOTS_PATH, file_name='tplot_heatmap_1d.png')
+
+@fig_test
+def test_plot_trial_heatmaps():
+
+    temp = np.array([[0., 1., 2.], [0., 2., 1.], [0., 3., 2.]])
+    data = np.stack([temp, temp])
+
+    plot_trial_heatmaps(data,
+                        file_path=TEST_PLOTS_PATH, file_name='tplot_trial_heatmaps.png')
 
 def test_create_heat_title():
 

--- a/spiketools/tests/plts/test_utils.py
+++ b/spiketools/tests/plts/test_utils.py
@@ -2,6 +2,7 @@
 
 import os
 
+from spiketools.tests.tutils import fig_test
 from spiketools.tests.tsettings import TEST_PLOTS_PATH
 
 from spiketools.plts.utils import *
@@ -99,6 +100,7 @@ def test_set_plt_kwargs():
     example_plot(title=title)
     assert plt.gca().get_title() == title
 
+@fig_test
 def test_make_axes():
 
     n_axes = 5
@@ -116,6 +118,7 @@ def test_make_grid():
     assert grid.nrows == nrows
     assert grid.ncols == ncols
 
+@fig_test
 def test_get_grid_subplot():
 
     grid = make_grid(2, 2)

--- a/spiketools/tests/tutils.py
+++ b/spiketools/tests/tutils.py
@@ -28,3 +28,26 @@ def plot_test(func):
         assert ax.has_data()
 
     return wrapper
+
+
+def fig_test(func):
+    """Decorator for simple testing of function that create a figure.
+
+    Notes
+    -----
+    This decorator closes all plots prior to the test.
+    After running the test function, it checks a figure was created, including an axis.
+    It therefore performs a minimal test - asserting the figure exists, with no accuracy checking.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        plt.close('all')
+
+        func(*args, **kwargs)
+
+        fig = plt.gcf()
+        assert fig.axes
+
+    return wrapper


### PR DESCRIPTION
This is a quick extension that adds a `plot_trial_heatmaps`, a helper function to plot heatmaps for individual trials, all together. 

It also adds some associated code to help with managing parameters and testing this kind of function. 