### PR TITLE
[ENH] - Fix up management of edges checks & warnings

### DIFF
--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -62,7 +62,7 @@ def compute_bin_edges(position, bins, area_range=None):
         return x_edges, y_edges
 
 
-def compute_bin_assignment(position, x_edges, y_edges=None, include_edge=True):
+def compute_bin_assignment(position, x_edges, y_edges=None, check_range=True, include_edge=True):
     """Compute spatial bin assignment.
 
     Parameters
@@ -70,12 +70,12 @@ def compute_bin_assignment(position, x_edges, y_edges=None, include_edge=True):
     position : 1d or 2d array
         Position values.
     x_edges : 1d array
-        Edge definitions for the spatial binning.
-        Values within the arrays should be monotonically increasing.
+        Edge definitions for the x dimension of the spatial binning.
     y_edges : 1d array, optional, default: None
-        Edge definitions for the spatial binning.
-        Values within the arrays should be monotonically increasing.
-        Used in 2d case only.
+        Edge definitions for the y dimension of the spatial binning. Only used if position is 2d.
+    check_range : bool, optional, default: True
+        Whether to check if the given edges fully cover the given data.
+        If True, runs a check that raises a warning if any data values exceed edge ranges.
     include_edge : bool, optional, default: True
         Whether to include positions on the edge into the bin.
 
@@ -88,10 +88,11 @@ def compute_bin_assignment(position, x_edges, y_edges=None, include_edge=True):
 
     Notes
     -----
-    - In the case of zero outliers (all positions are between edge ranges), the returned
-      values are encoded as bin position, with values between {0, n_bins-1}.
-    - If there are outliers (some position values that are outside the given edges definitions),
-      these are encoded as -1 (left side) or n_bins (right side). A warning will be raised.
+    - Values in the edge array(s) should be monotonically increasing.
+    - If there are no outliers (all position values are between edge ranges), the returned
+      bin assignments will range from (0, n_bins-1).
+    - Outliers (position values beyond the given edges definitions), will be encoded as -1
+      (left side) or `n_bins` (right side). If `check_range` is True, a warning will be raised.
     - By default position values equal to the left-most & right-most edges are treated as
       within the bounds (not treated as outliers), unless `include_edge` is set as False.
 

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -122,7 +122,7 @@ def compute_bin_assignment(position, x_edges, y_edges=None, include_edge=True):
         x_bins = np.digitize(position, x_edges, right=False)
 
         if include_edge:
-            x_bins = _include_bin_edge(position, x_bins, x_edges, side='left')
+            x_bins = _include_bin_edge(x_bins, position, x_edges, side='left')
 
         return x_bins - 1
 
@@ -134,8 +134,8 @@ def compute_bin_assignment(position, x_edges, y_edges=None, include_edge=True):
         y_bins = np.digitize(position[1, :], y_edges, right=False)
 
         if include_edge:
-            x_bins = _include_bin_edge(position[0, :], x_bins, x_edges, side='left')
-            y_bins = _include_bin_edge(position[1, :], y_bins, y_edges, side='left')
+            x_bins = _include_bin_edge(x_bins, position[0, :], x_edges, side='left')
+            y_bins = _include_bin_edge(y_bins, position[1, :], y_edges, side='left')
 
         return x_bins - 1, y_bins - 1
 
@@ -474,23 +474,23 @@ def compute_occupancy(position, timestamps, bins, area_range=None,
     return occupancy
 
 
-def _include_bin_edge(position, bin_pos, edges, side='left'):
+def _include_bin_edge(assignments, position, edges, side='left'):
     """Update bin assignment so last bin includes edge values.
 
     Parameters
     ----------
+    assignments : 1d array
+        The bin assignment for each position.
     position : 1d array
         Position values.
-    bin_pos : 1d array
-        The bin assignment for each position.
     edges : 1d array
-        The bin edge definitions.
+        The bin edges.
     side : {'left', 'right'}
         Which side was used to compute bin assignment.
 
     Returns
     -------
-    bin_pos : 1d array
+    assignments : 1d array
         The bin assignment for each position.
 
     Notes
@@ -507,12 +507,12 @@ def _include_bin_edge(position, bin_pos, edges, side='left'):
 
         # If side left, right position == edge gets set as len(bins), so decrement by 1
         mask = position == edges[-1]
-        bin_pos[mask] = bin_pos[mask] - 1
+        assignments[mask] = assignments[mask] - 1
 
     elif side == 'right':
 
         # If side right, left position == edge gets set as 0, so increment by 1
         mask = position == edges[0]
-        bin_pos[mask] = bin_pos[mask] + 1
+        assignments[mask] = assignments[mask] + 1
 
-    return bin_pos
+    return assignments

--- a/spiketools/spatial/place.py
+++ b/spiketools/spatial/place.py
@@ -123,6 +123,10 @@ def compute_trial_place_bins(spikes, position, timestamps, bins, trial_starts, t
                                                       t_speed, speed_threshold, time_threshold,
                                                       t_occ)
 
+        # This to turn off the range warning for subsequent loop iterations
+        #   This should be addressed by a warning filter, but that approach doesn't seem to work...
+        occupancy_kwargs['check_range'] = False
+
     if flatten:
         place_bins_trial = np.reshape(place_bins_trial, [len(trial_starts), compute_nbins(bins)])
 

--- a/spiketools/tests/spatial/test_occupancy.py
+++ b/spiketools/tests/spatial/test_occupancy.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from spiketools.spatial.occupancy import *
+from spiketools.spatial.occupancy import _include_bin_edge
 
 ###################################################################################################
 ###################################################################################################
@@ -44,26 +45,24 @@ def test_compute_bin_edges():
 
 def test_compute_bin_assignment():
 
-    # test with simple data, checking accuracy
-    position = np.array([[1, 3, 5, 7], [1, 3, 5, 7]])
-    x_edges = np.array([0, 2, 4, 6, 8])
-    y_edges = np.array([0, 2, 4, 6, 8])
-    x_bins, y_bins = compute_bin_assignment(position, x_edges, y_edges)
-    expected = np.array([0, 1, 2, 3])
-    assert isinstance(x_bins, np.ndarray)
-    assert isinstance(y_bins, np.ndarray)
-    assert np.array_equal(x_bins, expected)
-    assert np.array_equal(y_bins, expected)
+    # test 1d data
+    position = np.array([1, 3, 5, 7])
+    edges = np.array([0, 2, 4, 6, 8])
+    assgns = compute_bin_assignment(position, edges)
+    expected1 = np.array([0, 1, 2, 3])
+    assert isinstance(assgns, np.ndarray)
+    assert np.array_equal(assgns, expected1)
 
-    # test with larger, random data
-    position = np.random.uniform(0, 2, (2, 10))
-    x_edges = np.arange(0, 2.2, 0.2)
-    y_edges = np.arange(0, 2.2, 0.2)
+    # test 2d data
+    position = np.array([[1, 3, 5, 7], [11, 13, 15, 17]])
+    x_edges = np.array([0, 2, 4, 6, 8])
+    y_edges = np.array([10, 12, 14, 16, 18])
     x_bins, y_bins = compute_bin_assignment(position, x_edges, y_edges)
+    expected2 = np.array([0, 1, 2, 3])
     assert isinstance(x_bins, np.ndarray)
     assert isinstance(y_bins, np.ndarray)
-    assert position[0].shape == x_bins.shape
-    assert position[1].shape == y_bins.shape
+    assert np.array_equal(x_bins, expected1)
+    assert np.array_equal(y_bins, expected2)
 
 def test_compute_bin_counts_pos():
 
@@ -145,9 +144,8 @@ def test_create_position_df():
 
 def test_compute_occupancy_df():
 
-    data_dict = {
-        'time' : np.array([5, 5, 5, 5, 5, 5, 5, 5, 5.]),
-        'xbin' : np.array([0, 0, 0, 0, 1, 1, 1, 2, 2])}
+    data_dict = {'time' : np.array([5, 5, 5, 5, 5, 5, 5, 5, 5.]),
+                 'xbin' : np.array([0, 0, 0, 0, 1, 1, 1, 2, 2])}
 
     # check 1d case
     bins = 3
@@ -201,3 +199,19 @@ def test_compute_occupancy():
 
     # Test flipped binning should get the same total occupancy
     assert np.nansum(occ) == np.nansum(compute_occupancy(position, timestamps, [bins[1], bins[0]]))
+
+def test_include_bin_edge():
+
+    edges = np.array([0, 1, 2])
+
+    # test left side case
+    assignments = np.array([1, 2, 3])
+    position = np.array([0.5, 1.5, 2])
+    out = _include_bin_edge(assignments, position, edges, side='left')
+    assert np.array_equal(out, np.array([1, 2, 2]))
+
+    # test right right case
+    assignments = np.array([0, 1, 2])
+    position = np.array([0, 0.5, 1.5])
+    out = _include_bin_edge(assignments, position, edges, side='right')
+    assert np.array_equal(out, np.array([1, 1, 2]))

--- a/spiketools/tests/spatial/test_occupancy.py
+++ b/spiketools/tests/spatial/test_occupancy.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 from spiketools.spatial.occupancy import *
-from spiketools.spatial.occupancy import _include_bin_edge
 
 ###################################################################################################
 ###################################################################################################
@@ -199,19 +198,3 @@ def test_compute_occupancy():
 
     # Test flipped binning should get the same total occupancy
     assert np.nansum(occ) == np.nansum(compute_occupancy(position, timestamps, [bins[1], bins[0]]))
-
-def test_include_bin_edge():
-
-    edges = np.array([0, 1, 2])
-
-    # test left side case
-    assignments = np.array([1, 2, 3])
-    position = np.array([0.5, 1.5, 2])
-    out = _include_bin_edge(assignments, position, edges, side='left')
-    assert np.array_equal(out, np.array([1, 2, 2]))
-
-    # test right right case
-    assignments = np.array([0, 1, 2])
-    position = np.array([0, 0.5, 1.5])
-    out = _include_bin_edge(assignments, position, edges, side='right')
-    assert np.array_equal(out, np.array([1, 1, 2]))

--- a/spiketools/tests/utils/test_data.py
+++ b/spiketools/tests/utils/test_data.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from spiketools.utils.data import *
+from spiketools.utils.data import _include_bin_edge
 
 ###################################################################################################
 ###################################################################################################
@@ -44,3 +45,29 @@ def test_drop_nans():
     out = drop_nans(data)
     assert isinstance(out, np.ndarray)
     assert np.array_equal(out, np.array([[0.5, 1.0, 1.5, 2.0, 2.5], [0.5, 1.0, 1.5, 2.0, 2.5]]))
+
+def test_assign_data_to_bins():
+
+    data = np.array([1, 3, 5, 7])
+    edges = np.array([0, 2, 4, 6, 8])
+    assgns = assign_data_to_bins(data, edges)
+    expected = np.array([0, 1, 2, 3])
+    assert isinstance(assgns, np.ndarray)
+    assert np.array_equal(assgns, expected)
+
+def test_include_bin_edge():
+
+    edges = np.array([0, 1, 2])
+
+    # test left side case
+    assignments = np.array([1, 2, 3])
+    position = np.array([0.5, 1.5, 2])
+    out = _include_bin_edge(assignments, position, edges, side='left')
+    assert np.array_equal(out, np.array([1, 2, 2]))
+
+    # test right right case
+    assignments = np.array([0, 1, 2])
+    position = np.array([0, 0.5, 1.5])
+    out = _include_bin_edge(assignments, position, edges, side='right')
+    assert np.array_equal(out, np.array([1, 1, 2]))
+

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -86,20 +86,21 @@ def infer_time_unit(time_values):
     return time_unit
 
 
-def check_bin_range(values, bin_edges):
+def check_bin_range(values, bin_area):
     """Checks data values against given bin edges, warning if values exceed bin range.
 
     Parameters
     ----------
     values : 1d array
         A set of value to check against bin edges.
-    bin_edges : 1d array
-        The bin edges to use to check.
+    bin_area : 1d array or list
+        The bin range area to check. Can be a two-item area range, or an array of bin edges.
     """
 
     if values.size > 0:
-        if np.nanmin(values) < bin_edges[0] or np.nanmax(values) > bin_edges[-1]:
-            warnings.warn('The data values extend beyond the given bin definition.')
+        if np.nanmin(values) < bin_area[0] or np.nanmax(values) > bin_area[-1]:
+            msg = 'The data values extend beyond the given bin definition.'
+            warnings.warn(msg)
 
 
 def check_time_bins(bins, values, trange=None, check_range=True):

--- a/spiketools/utils/data.py
+++ b/spiketools/utils/data.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from scipy.ndimage import gaussian_filter
 
+from spiketools.utils.checks import check_param_options, check_bin_range
+
 ###################################################################################################
 ###################################################################################################
 
@@ -83,3 +85,74 @@ def drop_nans(data):
         raise ValueError('Only 1d or 2d arrays supported.')
 
     return data
+
+
+def assign_data_to_bins(data, edges, include_edge=True):
+    """Assign data values to data bins, based on given edges.
+
+    Parameters
+    ----------
+    data : 1d array
+        Data values to bin.
+    edges : 1d array
+        Edge definitions for the binning.
+    include_edge : bool, optional, default: True
+        Whether to include data values on the edge into the bin.
+
+    Returns
+    -------
+    assignments : 1d array
+        Bin assignments per data value.
+    """
+
+    check_bin_range(data, edges)
+    assignments = np.digitize(data, edges, right=False)
+
+    if include_edge:
+        assignments = _include_bin_edge(assignments, data, edges, side='left')
+
+    return assignments - 1
+
+
+def _include_bin_edge(assignments, position, edges, side='left'):
+    """Update bin assignment so last bin includes edge values.
+
+    Parameters
+    ----------
+    assignments : 1d array
+        The bin assignment for each position.
+    position : 1d array
+        Position values.
+    edges : 1d array
+        The bin edges.
+    side : {'left', 'right'}
+        Which side was used to compute bin assignment.
+
+    Returns
+    -------
+    assignments : 1d array
+        The bin assignment for each position.
+
+    Notes
+    -----
+    For any position values that exactly match the left-most or right-most bin edges, by default
+    (from np.digitize), one of these sides will be considered an outlier. This is because bin
+    assignment is computed as `pos >= left_bin_edge & pos < right_bin_edge (flipped if right=True).
+    To address this, this function resets position values == edges as with the bin on the edge.
+    """
+
+    check_param_options(side, 'side', ['left', 'right'])
+
+    if side == 'left':
+
+        # If side left, right position == edge gets set as len(bins), so decrement by 1
+        mask = position == edges[-1]
+        assignments[mask] = assignments[mask] - 1
+
+    elif side == 'right':
+
+        # If side right, left position == edge gets set as 0, so increment by 1
+        mask = position == edges[0]
+        assignments[mask] = assignments[mask] + 1
+
+    return assignments

--- a/spiketools/utils/data.py
+++ b/spiketools/utils/data.py
@@ -87,7 +87,7 @@ def drop_nans(data):
     return data
 
 
-def assign_data_to_bins(data, edges, include_edge=True):
+def assign_data_to_bins(data, edges, check_range=True, include_edge=True):
     """Assign data values to data bins, based on given edges.
 
     Parameters
@@ -96,6 +96,9 @@ def assign_data_to_bins(data, edges, include_edge=True):
         Data values to bin.
     edges : 1d array
         Edge definitions for the binning.
+    check_range : bool, optional, default: True
+        Whether to check if the given edges fully cover the given data.
+        If True, runs a check that raises a warning if any data values exceed edge ranges.
     include_edge : bool, optional, default: True
         Whether to include data values on the edge into the bin.
 
@@ -105,7 +108,8 @@ def assign_data_to_bins(data, edges, include_edge=True):
         Bin assignments per data value.
     """
 
-    check_bin_range(data, edges)
+    if check_range:
+        check_bin_range(data, edges)
     assignments = np.digitize(data, edges, right=False)
 
     if include_edge:


### PR DESCRIPTION
This PR addresses some quirks with doing spatial binning and occupancy calculations if using an `area_range` that does not extend across the whole position range. If doing so (sub-selecting a range to look at), previously there were a bunch of warnings that could go a bit over the top - but as long as one intends to choose an area smaller than the whole field, that should be valid, so this fixes things up to do so more smoothly. 