### PR TITLE
[ENH] - Update `create_dataframe_bins`

### DIFF
--- a/spiketools/stats/anova.py
+++ b/spiketools/stats/anova.py
@@ -30,7 +30,8 @@ def create_dataframe(data, columns=None, drop_na=True, types=None):
     drop_na : bool, optional, default: True
         Whether to drop NaN values from the dataframe.
     types : dict, optional
-
+        A types to typecast columns too.
+        Each key should be a column label, and each associated value the type to typecast to.
 
     Returns
     -------
@@ -50,7 +51,7 @@ def create_dataframe(data, columns=None, drop_na=True, types=None):
     return df
 
 
-def create_dataframe_bins(bin_data, columns=None, other_data=None, drop_na=True):
+def create_dataframe_bins(bin_data, bin_columns=None, other_data=None, drop_na=True):
     """Create a dataframe from an array of binned data.
 
     Parameters
@@ -59,10 +60,10 @@ def create_dataframe_bins(bin_data, columns=None, other_data=None, drop_na=True)
         An array of data organized into pre-computed bins.
         If a 2d array, should be organized as [n_trials, n_bins].
         If a 3d array, should be organized as [n_trials, n_xbins, n_ybins].
-    columns : list of str, optional
+    bin_columns : list of str, optional
         The column labels for the bin data.
         Defaults to ['bin', 'fr'] for 1d bins or ['xbin', 'ybin' 'fr'] for 2d bins.
-    other_data : dict
+    other_data : dict, optional
         Additional data columns, reflecting data per trial, to add to the dataframe.
         Each key should be a column label and each value should be an array of length n_trials.
     drop_na : bool, optional, default: True
@@ -76,7 +77,7 @@ def create_dataframe_bins(bin_data, columns=None, other_data=None, drop_na=True)
 
     if bin_data.ndim == 2:
 
-        df_columns = ['bin', 'fr'] if not columns else deepcopy(columns)
+        df_columns = ['bin', 'fr'] if not bin_columns else deepcopy(bin_columns)
 
         n_trials, n_bins = bin_data.shape
 
@@ -87,7 +88,7 @@ def create_dataframe_bins(bin_data, columns=None, other_data=None, drop_na=True)
 
     elif bin_data.ndim == 3:
 
-        df_columns = ['xbin', 'ybin', 'fr'] if not columns else deepcopy(columns)
+        df_columns = ['xbin', 'ybin', 'fr'] if not bin_columns else deepcopy(bin_columns)
 
         n_trials, n_xbins, n_ybins = bin_data.shape
         n_bins = n_xbins * n_ybins
@@ -122,7 +123,7 @@ def fit_anova(df, formula, feature=None, return_type='f_val', anova_type=2):
     df : pd.DataFrame
         Dataframe of data to fit the ANOVA to.
     formula : str
-        The formula
+        The formula.
     feature : str, optional
         Which feature to extract from the model.
         Only used (and required) if `return_type` is 'f_val'.

--- a/spiketools/stats/anova.py
+++ b/spiketools/stats/anova.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 
+from spiketools.utils.base import flatten
 from spiketools.utils.checks import check_param_options
 from spiketools.modutils.dependencies import safe_import, check_dependency
 
@@ -49,17 +50,21 @@ def create_dataframe(data, columns=None, drop_na=True, types=None):
     return df
 
 
-def create_dataframe_bins(data, columns, drop_na=True):
+def create_dataframe_bins(bin_data, columns=None, other_data=None, drop_na=True):
     """Create a dataframe from an array of binned data.
 
     Parameters
     ----------
-    data : 2d or 3d array
+    bin_data : 2d or 3d array
         An array of data organized into pre-computed bins.
         If a 2d array, should be organized as [n_trials, n_bins].
         If a 3d array, should be organized as [n_trials, n_xbins, n_ybins].
-    columns : list of str
-        The column labels for the dataframe.
+    columns : list of str, optional
+        The column labels for the bin data.
+        Defaults to ['bin', 'fr'] for 1d bins or ['xbin', 'ybin' 'fr'] for 2d bins.
+    other_data : dict
+        Additional data columns, reflecting data per trial, to add to the dataframe.
+        Each key should be a column label and each value should be an array of length n_trials.
     drop_na : bool, optional, default: True
         Whether to drop NaN values from the dataframe.
 
@@ -69,30 +74,41 @@ def create_dataframe_bins(data, columns, drop_na=True):
         Constructed dataframe.
     """
 
-    df_columns = deepcopy(columns)
+    if bin_data.ndim == 2:
 
-    if data.ndim == 2:
+        df_columns = ['bin', 'fr'] if not columns else deepcopy(columns)
 
-        n_trials, n_bins = data.shape
+        n_trials, n_bins = bin_data.shape
 
         trial = np.repeat(np.arange(0, n_trials), n_bins)
         labels = np.tile(np.arange(0, n_bins), n_trials)
 
-        df_data = np.stack([trial, labels, data.flatten()], axis=1)
+        df_data = np.stack([trial, labels, bin_data.flatten()], axis=1)
 
-    elif data.ndim == 3:
+    elif bin_data.ndim == 3:
 
-        n_trials, n_xbins, n_ybins = data.shape
+        df_columns = ['xbin', 'ybin', 'fr'] if not columns else deepcopy(columns)
+
+        n_trials, n_xbins, n_ybins = bin_data.shape
+        n_bins = n_xbins * n_ybins
 
         trial = np.repeat(np.arange(0, n_trials), n_xbins * n_ybins)
         xlabels = np.tile(np.repeat(np.arange(0, n_xbins), n_ybins), n_trials)
         ylabels = np.tile(np.arange(0, n_ybins), n_trials * n_xbins)
 
-        df_data = np.stack([trial, xlabels, ylabels, data.flatten()], axis=1)
+        df_data = np.stack([trial, xlabels, ylabels, bin_data.flatten()], axis=1)
+
+    if other_data is not None:
+        other_data = {label : np.repeat(data, n_bins) for label, data in other_data.items()}
+        df_columns.extend(other_data.keys())
+        df_data = np.hstack([df_data, np.array(list(other_data.values())).T])
 
     df_columns.insert(0, 'trial')
     types = {column : 'int' for column in df_columns if 'trial' in column or 'bin' in column}
     df = create_dataframe(df_data, df_columns, drop_na=drop_na, types=types)
+
+    # Reorder dataframe so that `trial` column is first and `fr` is at the end & sorted in between
+    df = df[flatten([['trial'], sorted(list(set(df.columns) - set(['trial', 'fr']))), ['fr']])]
 
     return df
 

--- a/spiketools/tests/stats/test_anova.py
+++ b/spiketools/tests/stats/test_anova.py
@@ -26,26 +26,34 @@ def test_create_dataframe(tdata2d):
 def test_create_dataframe_bins():
 
     # Create data - 3 trials, 2 bins, each bin value matches trial index
-    data2d = np.array([[0, 0], [1, 1], [2, 2]])
-    df = create_dataframe_bins(data2d, ['bin', 'fr'])
+    data2da = np.array([[0, 0], [1, 1], [2, 2]])
+    df = create_dataframe_bins(data2da, ['bin', 'fr'])
     assert isinstance(df, pd.DataFrame)
-    for ind, row in enumerate(data2d):
+    for ind, row in enumerate(data2da):
         df[df['trial'] == ind]['fr'].values == row
 
     # Create new data, where each bin value matches bin index
-    data2d = np.array([[0, 1, 2],
+    data2db = np.array([[0, 1, 2],
                        [0, 1, 2]])
-    df = create_dataframe_bins(data2d, ['bin', 'fr'])
-    for ind in range(0, np.max(data2d) + 1):
+    df = create_dataframe_bins(data2db, ['bin', 'fr'])
+    for ind in range(0, np.max(data2db) + 1):
         assert np.all(df[df['bin'] == ind]['fr'].values == ind)
 
-    # Check 3d array
+    # Check 3d array - 3 trials, with a [2, 3] bin definition
     data3d = np.array([[[0, 1, 2], [3, 4, 5]],
-                       [[6, 7, 8], [9, 10, 11]]])
+                       [[6, 7, 8], [9, 10, 9]],
+                       [[8, 7, 6], [5, 4, 3]]])
     df = create_dataframe_bins(data3d, ['xbin', 'ybin', 'fr'])
     assert isinstance(df, pd.DataFrame)
     for trial, ax, bx, fr in zip(df['trial'], df['xbin'], df['ybin'], df['fr']):
         assert data3d[trial, ax, bx] == fr
+
+    # Check adding additional data arrays - adding data that matches trial number
+    other_data = {'extra' : np.array([0, 1, 2])}
+    df = create_dataframe_bins(data2da, ['bin', 'fr'], other_data)
+    assert np.array_equal(df.trial.values, df.extra.values)
+    df = create_dataframe_bins(data3d, ['xbin', 'ybin', 'fr'], other_data)
+    assert np.array_equal(df.trial.values, df.extra.values)
 
 def test_fit_anova(tdata2d):
 

--- a/spiketools/tests/stats/test_anova.py
+++ b/spiketools/tests/stats/test_anova.py
@@ -34,7 +34,7 @@ def test_create_dataframe_bins():
 
     # Create new data, where each bin value matches bin index
     data2db = np.array([[0, 1, 2],
-                       [0, 1, 2]])
+                        [0, 1, 2]])
     df = create_dataframe_bins(data2db, ['bin', 'fr'])
     for ind in range(0, np.max(data2db) + 1):
         assert np.all(df[df['bin'] == ind]['fr'].values == ind)


### PR DESCRIPTION
This PR extends bin df creation to accept extra data columns. This can be useful when adding additional trial-level information to dataframes (for example, for splitter cell analyses in T3). 