### PR TITLE
[ENH] - Add functionality for dealing with gaps

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -363,6 +363,9 @@ Extract
    get_values_by_time_range
    threshold_spikes_by_times
    threshold_spikes_by_values
+   drop_range
+   reinstate_range
+   reinstate_range_2d
 
 Timestamps
 ~~~~~~~~~~

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -365,7 +365,6 @@ Extract
    threshold_spikes_by_values
    drop_range
    reinstate_range
-   reinstate_range_2d
 
 Timestamps
 ~~~~~~~~~~

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -73,16 +73,16 @@ def drop_shuffle_range(func):
 
     Notes
     -----
-    This function expects a `shuffle_xx` function, which takes 1d array `spikes` as the
-    first input and returns a 2d array `shuffled_spikes` as the sole output.
+    This function is designed for `shuffle_xx` functions, which takes 1d array `spikes` as
+    the first input and return a 2d array `shuffled_spikes` as the sole output.
 
     If a keyword argument `drop_time_range` is present, this triggers the drop process:
 
     - The given drop range time is dropped from the given spike times, before shuffling
-    - The shuffle function is then run
+    - The shuffle function is then run, without the dropped range
     - The drop range time is then reinstated in the shuffled spike times
 
-    If the `drop_time_range` is not present, this decorator does nothing.
+    If `drop_time_range` is not present in the arguments, this decorator does nothing.
     """
 
     @wraps(func)

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -10,7 +10,7 @@ from spiketools.measures.conversions import (convert_times_to_train, convert_isi
 from spiketools.stats.generators import poisson_generator
 from spiketools.stats.permutations import vec_perm
 from spiketools.utils.checks import check_param_options
-from spiketools.utils.extract import drop_range, reinstate_range_2d
+from spiketools.utils.extract import drop_range, reinstate_range
 
 ###################################################################################################
 ###################################################################################################
@@ -98,7 +98,7 @@ def drop_shuffle_range(func):
         shuffles = func(spikes, *args[1:], **kwargs)
 
         if time_range:
-            shuffles = reinstate_range_2d(shuffles, time_range)
+            shuffles = reinstate_range(shuffles, time_range)
 
         return shuffles
 

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -1,5 +1,7 @@
 """Functions for shuffling data."""
 
+from functools import wraps
+
 import numpy as np
 
 from spiketools.measures import compute_isis, compute_firing_rate
@@ -8,6 +10,7 @@ from spiketools.measures.conversions import (convert_times_to_train, convert_isi
 from spiketools.stats.generators import poisson_generator
 from spiketools.stats.permutations import vec_perm
 from spiketools.utils.checks import check_param_options
+from spiketools.utils.extract import drop_range, reinstate_range_2d
 
 ###################################################################################################
 ###################################################################################################
@@ -65,6 +68,44 @@ def shuffle_spikes(spikes, approach='ISI', n_shuffles=1000, **kwargs):
     return shuffled_spikes
 
 
+def drop_shuffle_range(func):
+    """Decorator for shuffling functions that allows for dropping a time range for shuffling.
+
+    Notes
+    -----
+    This function expects a `shuffle_xx` function, which takes 1d array `spikes` as the
+    first input and returns a 2d array `shuffled_spikes` as the sole output.
+
+    If a keyword argument `drop_time_range` is present, this triggers the drop process:
+
+    - The given drop range time is dropped from the given spike times, before shuffling
+    - The shuffle function is then run
+    - The drop range time is then reinstated in the shuffled spike times
+
+    If the `drop_time_range` is not present, this decorator does nothing.
+    """
+
+    @wraps(func)
+    def decorated(*args, **kwargs):
+
+        spikes = args[0]
+        time_range = kwargs.pop('drop_time_range', None)
+        check_empty = kwargs.pop('check_empty', True)
+
+        if time_range:
+            spikes = drop_range(spikes, time_range, check_empty)
+
+        shuffles = func(spikes, *args[1:], **kwargs)
+
+        if time_range:
+            shuffles = reinstate_range_2d(shuffles, time_range)
+
+        return shuffles
+
+    return decorated
+
+
+@drop_shuffle_range
 def shuffle_isis(spikes, n_shuffles=1000):
     """Create shuffled spike times using permuted inter-spike intervals.
 
@@ -98,6 +139,7 @@ def shuffle_isis(spikes, n_shuffles=1000):
     return shuffled_spikes
 
 
+@drop_shuffle_range
 def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000):
     """Shuffle data with circular shuffles of randomly sized bins of the spike train.
 
@@ -177,6 +219,7 @@ def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000):
     return shuffled_spikes
 
 
+@drop_shuffle_range
 def shuffle_poisson(spikes, n_shuffles=1000):
     """Shuffle spikes based on a Poisson distribution.
 
@@ -217,6 +260,7 @@ def shuffle_poisson(spikes, n_shuffles=1000):
     return shuffled_spikes
 
 
+@drop_shuffle_range
 def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000):
     """Shuffle spikes based on circularly shifting the spike train.
 

--- a/spiketools/tests/stats/test_shuffle.py
+++ b/spiketools/tests/stats/test_shuffle.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from spiketools.utils import set_random_seed
+from spiketools.utils.extract import drop_range
 
 from spiketools.stats.shuffle import *
 
@@ -17,6 +18,27 @@ def test_shuffle_spikes(tspikes):
     for approach, kwarg in zip(approaches, kwargs):
         shuffled = shuffle_spikes(tspikes, approach=approach, n_shuffles=1, **kwarg)
         assert isinstance(shuffled, np.ndarray)
+
+def test_drop_shuffle_range():
+
+    # Mock shuffle function
+    @drop_shuffle_range
+    def _shuffle_spikes(spikes, n_shuffles=2):
+        return np.array([spikes + 1] * n_shuffles)
+
+    n_shuffles = 2
+    spikes = np.array([0.5, 1.5, 1.9, 4.1, 5.4, 5.9])
+
+    # Check without activating decorator
+    out = _shuffle_spikes(spikes, n_shuffles)
+    assert np.allclose(out, np.array([spikes + 1] * n_shuffles))
+
+    # Check with applying a drop range
+    #   This test the spikes that get moved from the empty range (spikes @ ind: [1, 2])
+    drop_time_range = [2, 4]
+    out = _shuffle_spikes(spikes, n_shuffles, drop_time_range=drop_time_range)
+    toutput = np.array([0.5, 3.5, 3.9, 4.1, 5.4, 5.9])
+    assert np.allclose(out, np.array([toutput + 1] * n_shuffles))
 
 def test_shuffle_isis(tspikes):
 

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -154,6 +154,14 @@ def test_drop_range():
     with raises(AssertionError):
         out = drop_range(spikes, [1.5, 4])
 
+    # Test multiple time ranges
+    spikes = np.array([0.5, 1.5, 1.9, 4.1, 5.4, 5.9, 8.2, 9.7])
+    time_ranges = [[2, 4], [6, 8]]
+    out = drop_range(spikes, time_ranges)
+    assert isinstance(out, np.ndarray)
+    assert spikes.shape == out.shape
+    assert np.allclose(out, np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9, 4.2, 5.7]))
+
 def test_reinstate_range_1d():
 
     spikes = np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9])

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -5,6 +5,7 @@ import numpy as np
 from pytest import raises
 
 from spiketools.utils.extract import *
+from spiketools.utils.extract import _reinstate_range_1d
 
 ###################################################################################################
 ###################################################################################################
@@ -153,24 +154,24 @@ def test_drop_range():
     with raises(AssertionError):
         out = drop_range(spikes, [1.5, 4])
 
-def test_reinstate_range():
+def test_reinstate_range_1d():
 
     spikes = np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9])
     time_range = [2, 4]
 
-    out = reinstate_range(spikes, time_range)
+    out = _reinstate_range_1d(spikes, time_range)
     assert isinstance(out, np.ndarray)
     assert spikes.shape == out.shape
     assert get_range(out, *time_range).size == 0
     assert np.allclose(out, np.array([0.5, 1.5, 1.9, 4.1, 5.4, 5.9]))
 
-def test_reinstate_range_2d():
+def test_reinstate_range():
 
     spikes = np.array([[0.5, 1.5, 1.9, 2.1, 3.4, 3.9],
                        [0.2, 0.8, 1.2, 1.8, 2.5, 3.2]])
     time_range = [2, 4]
 
-    out = reinstate_range_2d(spikes, time_range)
+    out = reinstate_range(spikes, time_range)
 
     assert isinstance(out, np.ndarray)
     for row in out:

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -179,3 +179,15 @@ def test_reinstate_range():
         assert get_range(row, *time_range).size == 0
     assert np.allclose(out, np.array([[0.5, 1.5, 1.9, 4.1, 5.4, 5.9],
                                       [0.2, 0.8, 1.2, 1.8, 4.5, 5.2]]))
+
+    # Test multiple time ranges
+    time_ranges = [[1, 2], [3, 4]]
+    out = reinstate_range(spikes, time_ranges)
+
+    assert isinstance(out, np.ndarray)
+    for row in out:
+        assert len(row) == spikes.shape[1]
+        for time_range in time_ranges:
+            assert get_range(row, *time_range).size == 0
+    assert np.allclose(out, np.array([[0.5, 2.5, 2.9, 4.1, 5.4, 5.9],
+                                      [0.2, 0.8, 2.2, 2.8, 4.5, 5.2]]))

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from pytest import raises
+
 from spiketools.utils.extract import *
 
 ###################################################################################################
@@ -136,3 +138,43 @@ def test_threshold_spikes_by_values():
 
     out2 = threshold_spikes_by_values(spikes, times, values, dthresh, tthresh, comp_type='less')
     assert np.array_equal(out2, np.array([0.5, 2.5]))
+
+def test_drop_range():
+
+    spikes = np.array([0.5, 1.5, 1.9, 4.1, 5.4, 5.9])
+    time_range = [2, 4]
+
+    out = drop_range(spikes, time_range)
+    assert isinstance(out, np.ndarray)
+    assert spikes.shape == out.shape
+    assert np.allclose(out, np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9]))
+
+    # check that error is raised with no empty range
+    with raises(AssertionError):
+        out =drop_range(spikes, [1.5, 4])
+
+def test_reinstate_range():
+
+    spikes = np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9])
+    time_range = [2, 4]
+
+    out = reinstate_range(spikes, time_range)
+    assert isinstance(out, np.ndarray)
+    assert spikes.shape == out.shape
+    assert get_range(out, *time_range).size == 0
+    assert np.allclose(out, np.array([0.5, 1.5, 1.9, 4.1, 5.4, 5.9]))
+
+def test_reinstate_range_2d():
+
+    spikes = np.array([[0.5, 1.5, 1.9, 2.1, 3.4, 3.9],
+                       [0.2, 0.8, 1.2, 1.8, 2.5, 3.2]])
+    time_range = [2, 4]
+
+    out = reinstate_range_2d(spikes, time_range)
+
+    assert isinstance(out, np.ndarray)
+    for row in out:
+        assert len(row) == spikes.shape[1]
+        assert get_range(row, *time_range).size == 0
+    assert np.allclose(out, np.array([[0.5, 1.5, 1.9, 4.1, 5.4, 5.9],
+                                      [0.2, 0.8, 1.2, 1.8, 4.5, 5.2]]))

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -151,7 +151,7 @@ def test_drop_range():
 
     # check that error is raised with no empty range
     with raises(AssertionError):
-        out =drop_range(spikes, [1.5, 4])
+        out = drop_range(spikes, [1.5, 4])
 
 def test_reinstate_range():
 

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -426,12 +426,12 @@ def drop_range(spikes, time_range, check_empty=True):
     return out_spikes
 
 
-def reinstate_range(spikes, time_range):
+def _reinstate_range_1d(spikes, time_range):
     """Reinstate a dropped time range into a vector of spike times.
 
     Parameters
     ----------
-    spikes : 1d
+    spikes : 1d array
         Spike times, in seconds.
     time_range : list of [float, float]
         Time range to reinstate into spike times, as [start_add_time, end_add_time].
@@ -449,24 +449,31 @@ def reinstate_range(spikes, time_range):
     return out_spikes
 
 
-def reinstate_range_2d(spikes, time_range):
-    """Reinstate a dropped time range into a 2d array of spike times.
+def reinstate_range(spikes, time_range):
+    """Reinstate a dropped time range into an array of spike times.
 
     Parameters
     ----------
-    spikes : 2d array
+    spikes : 1d or 2d array
         An array of spikes times, in seconds.
     time_range : list of [float, float]
         Time range to reinstate into shuffled spike times, as [start_add_time, end_add_time].
 
     Returns
     -------
-    spikes_out : 2d array
+    spikes_out : 1d or 2d array
         An array of spikes times, in seconds, with the time range reinstated.
     """
 
+    assert spikes.ndim < 3, 'The reinstate_range function only supports 1d or 2d arrays.'
+
+    # By enforcing 2d (and later squeezing), the loops works for both 1d & 2d arrays
+    spikes = np.atleast_2d(spikes)
+
     spikes_out = np.zeros_like(spikes)
     for ind, spike in enumerate(spikes):
-        spikes_out[ind, :] = reinstate_range(spike, time_range)
+        spikes_out[ind, :] = _reinstate_range_1d(spike, time_range)
+
+    spikes_out = np.squeeze(spikes_out)
 
     return spikes_out

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -456,8 +456,9 @@ def reinstate_range(spikes, time_range):
     ----------
     spikes : 1d or 2d array
         An array of spikes times, in seconds.
-    time_range : list of [float, float]
-        Time range to reinstate into shuffled spike times, as [start_add_time, end_add_time].
+    time_range : list of [float, float] or list of list of [float, float]
+        Time range(s) to reinstate into shuffled spike times.
+        Each time range should be defined as [start_add_time, end_add_time].
 
     Returns
     -------
@@ -467,13 +468,15 @@ def reinstate_range(spikes, time_range):
 
     assert spikes.ndim < 3, 'The reinstate_range function only supports 1d or 2d arrays.'
 
+    # Operate on a copy of the input, to not overwrite original array
+    spikes = spikes.copy()
+
     # By enforcing 2d (and later squeezing), the loops works for both 1d & 2d arrays
     spikes = np.atleast_2d(spikes)
+    for trange in np.array(time_range, ndmin=2):
+        for ind, spikes_1d in enumerate(spikes):
+            spikes[ind, :] = _reinstate_range_1d(spikes_1d, trange)
 
-    spikes_out = np.zeros_like(spikes)
-    for ind, spike in enumerate(spikes):
-        spikes_out[ind, :] = _reinstate_range_1d(spike, time_range)
+    spikes = np.squeeze(spikes)
 
-    spikes_out = np.squeeze(spikes_out)
-
-    return spikes_out
+    return spikes

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -394,3 +394,79 @@ def threshold_spikes_by_values(spikes, times, values, data_threshold,
     spikes = spikes[get_comp_func(comp_type)(values, data_threshold)]
 
     return spikes
+
+
+def drop_range(spikes, time_range, check_empty=True):
+    """Drop a specified time range from a vector spike times.
+
+    Parameters
+    ----------
+    spikes : 1d array
+        Spike times, in seconds.
+    time_range : list of [float, float]
+        Time range to drop from spike times, as [start_drop_time, end_drop_time].
+    check_empty : bool, optional, default: True
+        Whether to check if the dropped range is empty of spikes.
+        If True, and there are spikes within the drop `time_range`, an error is raised.
+
+    Returns
+    -------
+    out_spikes : 1d array
+        Spike times, in seconds, with the time range removed.
+    """
+
+    if check_empty:
+        extracted = get_range(spikes, *time_range)
+        assert extracted.size == 0, "Extracted range is not empty."
+
+    tlen = time_range[1] - time_range[0]
+    out_spikes = np.hstack([get_range(spikes, max_value=time_range[0]),
+                            get_range(spikes, min_value=time_range[1], reset=tlen)])
+
+    return out_spikes
+
+
+def reinstate_range(spikes, time_range):
+    """Reinstate a dropped time range into a vector of spike times.
+
+    Parameters
+    ----------
+    spikes : 1d
+        Spike times, in seconds.
+    time_range : list of [float, float]
+        Time range to reinstate into spike times, as [start_add_time, end_add_time].
+
+    Returns
+    -------
+    out_spikes : 1d array
+        Spike times, in seconds, with the time range reinstated.
+    """
+
+    tlen = time_range[1] - time_range[0]
+    out_spikes = np.hstack([get_range(spikes, max_value=time_range[0]),
+                            get_range(spikes, min_value=time_range[0]) + tlen])
+
+    return out_spikes
+
+
+def reinstate_range_2d(spikes, time_range):
+    """Reinstate a dropped time range into a 2d array of spike times.
+
+    Parameters
+    ----------
+    spikes : 2d array
+        An array of spikes times, in seconds.
+    time_range : list of [float, float]
+        Time range to reinstate into shuffled spike times, as [start_add_time, end_add_time].
+
+    Returns
+    -------
+    spikes_out : 2d array
+        An array of spikes times, in seconds, with the time range reinstated.
+    """
+
+    spikes_out = np.zeros_like(spikes)
+    for ind, spike in enumerate(spikes):
+        spikes_out[ind, :] = reinstate_range(spike, time_range)
+
+    return spikes_out


### PR DESCRIPTION
This PR add functionality for dealing with 'gaps' in spike times (for example, if an amp was turned off for some time in the middle of an experiment), and in particular a strategy to dealing with this when shuffling spike times. 

It adds:
- utility functions for dropping out / adding back in 'gap' time range(s)
- a strategy for shuffling by dropping out a gap, shuffling, and then re-inserting the gap(s)