### PR TITLE
[ENH] - Add utils for working with trial level data

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -505,6 +505,19 @@ Utilities for epoching data.
    epoch_data_by_range
    epoch_data_by_segment
 
+Trials
+~~~~~~
+
+Utilities for working with trial-level data.
+
+.. currentmodule:: spiketools.utils.trials
+.. autosummary::
+   :toctree: generated/
+
+   split_trials_by_condition
+   split_trials_by_condition_list
+   split_trials_by_condition_array
+
 Run
 ~~~
 

--- a/spiketools/tests/utils/test_trials.py
+++ b/spiketools/tests/utils/test_trials.py
@@ -1,0 +1,40 @@
+"""Tests for spiketools.utils.trials"""
+
+import numpy as np
+
+from spiketools.utils.trials import *
+
+###################################################################################################
+###################################################################################################
+
+def test_split_trials_by_condition():
+
+    trials_lst = [[1, 2, 3], [1, 3], [1, 4, 5]]
+    trials_arr = np.array([[1, 2, 3], [2, 3, 4], [4, 5, 6]])
+    conditions = ['A', 'B', 'A']
+
+    # Note that accuracy checking done in sub-functions - this just checks execution
+    out_lst = split_trials_by_condition(trials_lst, conditions)
+    assert out_lst
+    out_arr = split_trials_by_condition(trials_arr, conditions)
+    assert out_arr
+
+def test_split_trials_by_condition_list():
+
+    trials = [[1, 2, 3], [1, 3], [1, 4, 5]]
+    conditions = ['A', 'B', 'A']
+
+    out = split_trials_by_condition_list(trials, conditions)
+
+    assert out['A'] == [[1, 2, 3], [1, 4, 5]]
+    assert out['B'] == [[1, 3]]
+
+def test_split_trials_by_condition_array():
+
+    trials = np.array([[1, 2, 3], [2, 3, 4], [4, 5, 6]])
+    conditions = ['A', 'B', 'A']
+
+    out = split_trials_by_condition_list(trials, conditions)
+
+    assert np.array_equal(out['A'], np.array([[1, 2, 3], [4, 5, 6]]))
+    assert np.array_equal(out['B'], np.array([[2, 3, 4]]))

--- a/spiketools/utils/trials.py
+++ b/spiketools/utils/trials.py
@@ -1,0 +1,85 @@
+"""Utility functions for working with trial-level data."""
+
+import numpy as np
+
+###################################################################################################
+###################################################################################################
+
+def split_trials_by_condition(trials, conditions):
+    """Split trial data by condition label.
+
+    Parameters
+    ----------
+    trials : list or 2d array
+        Trial data.
+        If list, each element of the list should represent a trial.
+        If array, with each row of the data frame should represent a trial.
+    conditions : list
+        Condition labels for each trial.
+
+    Returns
+    -------
+    split_trials : dict
+        The trial data, organized by condition.
+        Each key is a condition label with values as the data for that condition.
+    """
+
+    if isinstance(trials, list):
+        out = split_trials_by_condition_list(trials, conditions)
+    if isinstance(trials, np.ndarray):
+        out = split_trials_by_condition_array(trials, conditions)
+
+    return out
+
+def split_trials_by_condition_list(trials, conditions):
+    """Split trial data by condition label, for trial data as a list.
+
+    Parameters
+    ----------
+    trials : list
+        Trial data, with each element of the element representing a trial.
+    conditions : list
+        Condition labels for each trial.
+
+    Returns
+    -------
+    split_trials : dict
+        The trial data, organized by condition.
+        Each key is a condition label with values as the data for that condition.
+    """
+
+    msg = 'The number of trials and condition labels does not match.'
+    assert len(trials) == len(conditions), msg
+
+    out = {condition : [] for condition in set(conditions)}
+
+    for trial, condition in zip(trials, conditions):
+        out[condition].append(trial)
+
+    return out
+
+def split_trials_by_condition_array(trials, conditions):
+    """Split trial data by condition label, for trial data as an array.
+
+    Parameters
+    ----------
+    trials : 2d array
+        Trial data, with each row of the data frame representing a trial.
+    conditions : list
+        Condition labels for each trial.
+
+    Returns
+    -------
+    split_trials : dict
+        The trial data, organized by condition.
+        Each key is a condition label with values as the data for that condition.
+    """
+
+    msg = 'The number of trials and condition labels does not match.'
+    assert trials.shape[0] == len(conditions), msg
+
+    out = {}
+    for condition in set(conditions):
+        out[condition] = trials[np.where(np.array(conditions)==condition)[0], :]
+
+    return out

--- a/spiketools/utils/trials.py
+++ b/spiketools/utils/trials.py
@@ -12,8 +12,8 @@ def split_trials_by_condition(trials, conditions):
     ----------
     trials : list or 2d array
         Trial data.
-        If list, each element of the list should represent a trial.
-        If array, with each row of the data frame should represent a trial.
+        If list, each element should represent a trial.
+        If array, each row should represent a trial.
     conditions : list
         Condition labels for each trial.
 
@@ -37,7 +37,7 @@ def split_trials_by_condition_list(trials, conditions):
     Parameters
     ----------
     trials : list
-        Trial data, with each element of the element representing a trial.
+        Trial data, with each element representing a trial.
     conditions : list
         Condition labels for each trial.
 
@@ -64,7 +64,7 @@ def split_trials_by_condition_array(trials, conditions):
     Parameters
     ----------
     trials : 2d array
-        Trial data, with each row of the data frame representing a trial.
+        Trial data, with each row representing a trial.
     conditions : list
         Condition labels for each trial.
 


### PR DESCRIPTION
This PR adds a `utils.trials` file for utility functions for managing trial-level data. 

It adds some split functions, that are convenience functions for splitting up trials by a list of condition labels. This added for trials organized as lists of lists (eg. spike times) and for trials organized in an array (eg. firing rate across bins per trial). 