### PR TITLE
[ENH] - Add axis inverting helper function and apply to spatial plots

### DIFF
--- a/spiketools/plts/spatial.py
+++ b/spiketools/plts/spatial.py
@@ -9,7 +9,7 @@ from spiketools.utils.data import smooth_data, compute_range
 from spiketools.modutils.functions import get_function_parameters
 from spiketools.plts.annotate import add_dots
 from spiketools.plts.settings import DEFAULT_COLORS
-from spiketools.plts.utils import check_ax, make_axes, savefig
+from spiketools.plts.utils import check_ax, make_axes, savefig, invert_axes
 from spiketools.plts.style import set_plt_kwargs
 
 ###################################################################################################
@@ -17,8 +17,8 @@ from spiketools.plts.style import set_plt_kwargs
 
 @savefig
 @set_plt_kwargs
-def plot_positions(position, spike_positions=None, landmarks=None,
-                   x_bins=None, y_bins=None, ax=None, **plt_kwargs):
+def plot_positions(position, spike_positions=None, landmarks=None, x_bins=None,
+                   y_bins=None, invert=None, ax=None, **plt_kwargs):
     """Plot positions.
 
     Parameters
@@ -39,6 +39,9 @@ def plot_positions(position, spike_positions=None, landmarks=None,
     x_bins, y_bins : list of float, optional
         Bin edges for each axis.
         If provided, these are used to draw grid lines on the plot.
+    invert : {'x', 'y', 'both'}, optional
+        If provided, inverts the plot axes over x, y or both axes.
+        Note that invert x is equivalent to flipping the data left/right, and y to flipping up/down.
     ax : Axes, optional
         Axis object upon which to plot.
     plt_kwargs
@@ -81,11 +84,14 @@ def plot_positions(position, spike_positions=None, landmarks=None,
     if x_bins is not None or y_bins is not None:
         ax.grid()
 
+    if invert:
+        invert_axes(ax, invert)
+
 
 @savefig
 @set_plt_kwargs
 def plot_position_by_time(timestamps, position, spikes=None, spike_positions=None,
-                          ax=None, **plt_kwargs):
+                          invert=None, ax=None, **plt_kwargs):
     """Plot the position across time for a single dimension.
 
     Parameters
@@ -98,6 +104,9 @@ def plot_position_by_time(timestamps, position, spikes=None, spike_positions=Non
         Spike times, in seconds.
     spike_positions : 1d array, optional
         Position values of spikes, to indicate on the plot.
+    invert : {'x', 'y', 'both'}, optional
+        If provided, inverts the plot axes over x, y or both axes.
+        Note that invert x is equivalent to flipping the data left/right, and y to flipping up/down.
     ax : Axes, optional
         Axis object upon which to plot.
     plt_kwargs
@@ -114,12 +123,15 @@ def plot_position_by_time(timestamps, position, spikes=None, spike_positions=Non
 
     ax.set(xlabel='Time', ylabel='Position')
 
+    if invert:
+        invert_axes(ax, invert)
+
 
 @savefig
 @set_plt_kwargs
 def plot_heatmap(data, transpose=False, smooth=False, smoothing_kernel=1.5,
                  ignore_zero=False, cbar=False, cmap=None, vmin=None, vmax=None,
-                 ax=None, **plt_kwargs):
+                 invert=None, ax=None, **plt_kwargs):
     """Plot a spatial heat map.
 
     Parameters
@@ -140,8 +152,9 @@ def plot_heatmap(data, transpose=False, smooth=False, smoothing_kernel=1.5,
         Which colormap to use to plot.
     vmin, vmax : float, optional
         Min and max plot ranges.
-    title : str, optional
-        Title to add to the figure.
+    invert : {'x', 'y', 'both'}, optional
+        If provided, inverts the plot axes over x, y or both axes.
+        Note that invert x is equivalent to flipping the data left/right, and y to flipping up/down.
     ax : Axes, optional
         Axis object upon which to plot.
     plt_kwargs
@@ -179,6 +192,9 @@ def plot_heatmap(data, transpose=False, smooth=False, smoothing_kernel=1.5,
     if cbar:
         colorbar = plt.colorbar(im)
         colorbar.outline.set_visible(False)
+
+    if invert:
+        invert_axes(ax, invert)
 
 
 @savefig

--- a/spiketools/plts/spatial.py
+++ b/spiketools/plts/spatial.py
@@ -129,17 +129,15 @@ def plot_position_by_time(timestamps, position, spikes=None, spike_positions=Non
 
 @savefig
 @set_plt_kwargs
-def plot_heatmap(data, transpose=False, smooth=False, smoothing_kernel=1.5,
-                 ignore_zero=False, cbar=False, cmap=None, vmin=None, vmax=None,
-                 invert=None, ax=None, **plt_kwargs):
+def plot_heatmap(data, smooth=False, smoothing_kernel=1.5, ignore_zero=False,
+                 cbar=False, cmap=None, vmin=None, vmax=None,
+                 transpose=False, invert=None, ax=None, **plt_kwargs):
     """Plot a spatial heat map.
 
     Parameters
     ----------
     data : 2d array
         Measure to plot across a grided environment.
-    transpose : bool, optional, default: False
-        Whether to transpose the data before plotting.
     smooth : bool, optional, default: False
         Whether to smooth the data before plotting.
     smoothing_kernel : float, optional, default: 1.5
@@ -152,6 +150,8 @@ def plot_heatmap(data, transpose=False, smooth=False, smoothing_kernel=1.5,
         Which colormap to use to plot.
     vmin, vmax : float, optional
         Min and max plot ranges.
+    transpose : bool, optional, default: False
+        Whether to transpose the data before plotting.
     invert : {'x', 'y', 'both'}, optional
         If provided, inverts the plot axes over x, y or both axes.
         Note that invert x is equivalent to flipping the data left/right, and y to flipping up/down.

--- a/spiketools/plts/utils.py
+++ b/spiketools/plts/utils.py
@@ -204,9 +204,9 @@ def invert_axes(ax, invert):
 
     Notes
     -----
-    Note that inverting axes is equivalent to flipping the data, specifically:
-    Flipping up/down is equivalent to inverting the  y-axis.
-            Flipping left/right to inverting the x axis.
+    Note that for a 2d array, inverting axes is equivalent to flipping the data, specifically:
+        Flipping up/down is equivalent to inverting the y-axis.
+        Flipping left/right is equivalent to inverting the x-axis.
     """
 
     if invert in ['x', 'both']:

--- a/spiketools/plts/utils.py
+++ b/spiketools/plts/utils.py
@@ -190,3 +190,26 @@ def get_grid_subplot(grid, row, col, **plt_kwargs):
     """
 
     return plt.subplot(grid[row, col], **plt_kwargs)
+
+
+def invert_axes(ax, invert):
+    """Invert plot axes.
+
+    Parameters
+    ----------
+    ax : Axes
+        Axis object to update.
+    invert : {'x', 'y', 'both'} or None
+        How to invert the plot axes, inverting the x, y, or both axes.
+
+    Notes
+    -----
+    Note that inverting axes is equivalent to flipping the data, specifically:
+    Flipping up/down is equivalent to inverting the  y-axis.
+            Flipping left/right to inverting the x axis.
+    """
+
+    if invert in ['x', 'both']:
+        ax.invert_xaxis()
+    if invert in ['y', 'both']:
+        ax.invert_yaxis()

--- a/spiketools/tests/plts/test_utils.py
+++ b/spiketools/tests/plts/test_utils.py
@@ -85,3 +85,22 @@ def test_get_grid_subplot():
     grid = make_grid(2, 2)
     ax = get_grid_subplot(grid, 0, 0)
     assert ax
+
+def test_invert_axes():
+
+    # test inverting x & y axes separately
+    _, ax1 = plt.subplots()
+    ax1.plot([1, 2], [3, 4])
+
+    invert_axes(ax1, 'x')
+    assert ax1.get_xlim()[0] > ax1.get_xlim()[1]
+
+    invert_axes(ax1, 'y')
+    assert ax1.get_ylim()[0] > ax1.get_ylim()[1]
+
+    # test inverting both axes together
+    _, ax2 = plt.subplots()
+    ax2.plot([1, 2], [3, 4])
+    invert_axes(ax2, 'both')
+    assert ax2.get_xlim()[0] > ax2.get_xlim()[1]
+    assert ax2.get_ylim()[0] > ax2.get_ylim()[1]


### PR DESCRIPTION
This PR adds a helper function for inverting plot axes, and then links this in to the spatial plots, allowing for directly controlling the plot orientation for spatial plots. 

Note that in these cases, inverting plot axes is functionally equivalent to flipping a 2d data (where flipping the 2d array up/down is the same as inverting the y axis, and flipping a 2d array left/right is equivalent to inverting the x axis).

Note: this addition stems from a discussion (with @maestapereira, I think) about adding helper utilities for flipping position plot orientations, since sometimes the original orientation of the position data isn't the same as how we want to plot it. 