### PR TITLE
[ENH] - Update 1d vs 2d (rows & columns) support for array utilities

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -517,6 +517,7 @@ Utilities for working with trial-level data.
    split_trials_by_condition
    split_trials_by_condition_list
    split_trials_by_condition_array
+   recombine_trial_data
 
 Run
 ~~~

--- a/spiketools/plts/spatial.py
+++ b/spiketools/plts/spatial.py
@@ -5,7 +5,8 @@ from copy import deepcopy
 import numpy as np
 import matplotlib.pyplot as plt
 
-from spiketools.utils.data import smooth_data, compute_range
+from spiketools.utils.checks import check_array_lst_orientation
+from spiketools.utils.data import make_row_orientation, smooth_data, compute_range
 from spiketools.modutils.functions import get_function_parameters
 from spiketools.plts.annotate import add_dots
 from spiketools.plts.settings import DEFAULT_COLORS
@@ -51,8 +52,10 @@ def plot_positions(position, spike_positions=None, landmarks=None, x_bins=None,
     ax = check_ax(ax, figsize=plt_kwargs.pop('figsize', None))
 
     position = [position] if isinstance(position, np.ndarray) else position
+    orientation = check_array_lst_orientation(position)
+
     for cur_position in position:
-        ax.plot(*cur_position,
+        ax.plot(*make_row_orientation(cur_position, orientation),
                 color=plt_kwargs.pop('color', DEFAULT_COLORS[0]),
                 alpha=plt_kwargs.pop('alpha', 0.35),
                 **plt_kwargs)
@@ -60,17 +63,21 @@ def plot_positions(position, spike_positions=None, landmarks=None, x_bins=None,
     if spike_positions is not None:
         defaults = {'color' : 'red', 'alpha' : 0.4, 'ms' : 6}
         if isinstance(spike_positions, np.ndarray):
-            add_dots(spike_positions, ax=ax, **defaults)
+            add_dots(make_row_orientation(spike_positions, orientation),
+                     ax=ax, **defaults)
         elif isinstance(spike_positions, dict):
-            add_dots(spike_positions.pop('positions'), ax=ax, **{**defaults, **spike_positions})
+            add_dots(make_row_orientation(spike_positions.pop('positions'), orientation),
+                     ax=ax, **{**defaults, **spike_positions})
 
     if landmarks is not None:
         defaults = {'alpha' : 0.85, 'ms' : 12}
         for landmark in [landmarks] if not isinstance(landmarks, list) else landmarks:
             if isinstance(landmark, np.ndarray):
-                add_dots(landmark, ax=ax, **defaults)
+                add_dots(make_row_orientation(landmark, orientation),
+                         ax=ax, **defaults)
             elif isinstance(landmark, dict):
-                add_dots(landmark.pop('positions'), ax=ax, **landmark)
+                add_dots(make_row_orientation(landmark.pop('positions'), orientation),
+                         ax=ax, **landmark)
 
     if x_bins is not None:
         ax.set_xticks(x_bins, minor=False)

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -140,7 +140,7 @@ def compute_bin_assignment(position, x_edges, y_edges=None, check_range=True, in
         return x_bins, y_bins
 
 
-def compute_bin_counts_pos(position, bins, area_range=None, occupancy=None):
+def compute_bin_counts_pos(position, bins, area_range=None, occupancy=None, orientation=None):
     """Compute counts per bin, from position data.
 
     Parameters
@@ -156,6 +156,9 @@ def compute_bin_counts_pos(position, bins, area_range=None, occupancy=None):
     occupancy : 1d or 2d array, optional
         Occupancy across the spatial bins.
         If provided, used to normalize bin counts.
+    orientation : {'row', 'column'}, optional
+        The orientation of the position data.
+        If not provided, is inferred from the position data.
 
     Returns
     -------
@@ -188,7 +191,8 @@ def compute_bin_counts_pos(position, bins, area_range=None, occupancy=None):
         bin_counts, _ = np.histogram(position, bins=bins[0], range=area_range)
 
     elif position.ndim == 2:
-        bin_counts, _, _ = np.histogram2d(*get_position_xy(position), bins=bins, range=area_range)
+        bin_counts, _, _ = np.histogram2d(*get_position_xy(position, orientation=orientation),
+                                          bins=bins, range=area_range)
         bin_counts = bin_counts.T
 
     bin_counts = bin_counts.astype('int')

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from spiketools.utils.data import assign_data_to_bins
 from spiketools.spatial.checks import check_position, check_spatial_bins
-from spiketools.spatial.utils import compute_sample_durations
+from spiketools.spatial.utils import get_position_xy, compute_sample_durations
 
 ###################################################################################################
 ###################################################################################################
@@ -60,7 +60,8 @@ def compute_bin_edges(position, bins, area_range=None):
 
     elif len(bins) == 2:
 
-        x_pos, y_pos = position if isinstance(position, np.ndarray) else (None, None)
+        x_pos, y_pos = get_position_xy(position) \
+            if isinstance(position, np.ndarray) else (None, None)
         x_range, y_range = area_range if isinstance(area_range, list) else (None, None)
 
         x_edges = np.histogram_bin_edges(x_pos, bins=bins[0], range=x_range)
@@ -132,8 +133,9 @@ def compute_bin_assignment(position, x_edges, y_edges=None, check_range=True, in
 
     elif position.ndim == 2:
 
-        x_bins = assign_data_to_bins(position[0, :], x_edges, check_range, include_edge)
-        y_bins = assign_data_to_bins(position[1, :], y_edges, check_range, include_edge)
+        x_pos, y_pos = get_position_xy(position)
+        x_bins = assign_data_to_bins(x_pos, x_edges, check_range, include_edge)
+        y_bins = assign_data_to_bins(y_pos, y_edges, check_range, include_edge)
 
         return x_bins, y_bins
 
@@ -186,8 +188,7 @@ def compute_bin_counts_pos(position, bins, area_range=None, occupancy=None):
         bin_counts, _ = np.histogram(position, bins=bins[0], range=area_range)
 
     elif position.ndim == 2:
-        bin_counts, _, _ = np.histogram2d(position[0, :], position[1, :],
-                                          bins=bins, range=area_range)
+        bin_counts, _, _ = np.histogram2d(*get_position_xy(position), bins=bins, range=area_range)
         bin_counts = bin_counts.T
 
     bin_counts = bin_counts.astype('int')

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -2,12 +2,41 @@
 
 import numpy as np
 
-from spiketools.utils.checks import check_axis
 from spiketools.utils.data import compute_range
+from spiketools.utils.checks import check_axis, check_array_orientation
 from spiketools.spatial.checks import check_spatial_bins
 
 ###################################################################################################
 ###################################################################################################
+
+def get_position_xy(position, orientation=None):
+    """Get the x & y data vectors from a 2d position data array.
+
+    Parameters
+    ----------
+    position : 2d array
+        Position values.
+    orientation : {'row', 'column'}, optional
+        The orientation of the position data.
+        If not provided, is inferred from the given data.
+
+    Returns
+    -------
+    x_data, y_data : 1d array
+        Extracted X & Y position data.
+    """
+
+    assert position.ndim == 2, "Position data must be 2d to unpack X & Y dimensions."
+
+    orientation = check_array_orientation(position) if not orientation else orientation
+
+    if orientation == 'row':
+        x_data, y_data = position
+    else:
+        x_data, y_data = position[:, 0], position[:, 1]
+
+    return x_data, y_data
+
 
 def compute_nbins(bins):
     """Compute the number of bins for a given bin definition.

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from spiketools.utils.checks import check_axis
 from spiketools.utils.data import compute_range
 from spiketools.spatial.checks import check_spatial_bins
 
@@ -74,9 +75,7 @@ def compute_pos_ranges(position):
         ranges = [*compute_range(position)]
 
     elif position.ndim == 2:
-        ranges = []
-        for dim in range(position.shape[0]):
-            ranges.append([*compute_range(position[dim, :])])
+        ranges = np.apply_along_axis(compute_range, check_axis(None, position), position)
 
     else:
         raise ValueError('Position input should be 1d or 2d.')

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -104,7 +104,10 @@ def compute_pos_ranges(position):
         ranges = np.array(compute_range(position))
 
     elif position.ndim == 2:
-        ranges = list(np.apply_along_axis(compute_range, check_axis(None, position), position))
+        # Regardless of row / column input data, organizes output to have same orientation
+        axis = check_axis(None, position)
+        ranges = np.apply_along_axis(compute_range, axis, position)
+        ranges = list(ranges.T if axis == 0 else ranges)
 
     else:
         raise ValueError('Position input should be 1d or 2d.')

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -51,31 +51,31 @@ def compute_pos_ranges(position):
 
     Returns
     -------
-    ranges : list of float or list of list of float
+    ranges : 1d array or list of 1d array
         Ranges for each dimension in the spatial data.
 
     Examples
     --------
     Compute the 2D position ranges for:
-    (x, y) = (1.5, 6.5), (2.5, 7.5), (3.5, 8.5), (5, 9).
+    (x, y) = (1.5, 6.5), (2.5, 7.5), (3.5, 8.5), (5.1, 9.1).
 
-    >>> position = np.array([[1.5, 2.5, 3.5, 5], [6.5, 7.5, 8.5, 9]])
+    >>> position = np.array([[1.5, 2.5, 3.5, 5.1], [6.5, 7.5, 8.5, 9.1]])
     >>> compute_pos_ranges(position)
-    [[1.5, 5.0], [6.5, 9.0]]
+    [array([1.5, 5.1]), array([6.5, 9.1])]
 
     Compute the 1D position range for:
-    x = 1.5, 2.5, 3.5, 5.
+    x = 1.5, 2.5, 3.5, 5.1
 
-    >>> position = np.array([1.5, 2.5, 3.5, 5])
+    >>> position = np.array([1.5, 2.5, 3.5, 5.1])
     >>> compute_pos_ranges(position)
-    [1.5, 5.0]
+    array([1.5, 5.1])
     """
 
     if position.ndim == 1:
-        ranges = [*compute_range(position)]
+        ranges = np.array(compute_range(position))
 
     elif position.ndim == 2:
-        ranges = np.apply_along_axis(compute_range, check_axis(None, position), position)
+        ranges = list(np.apply_along_axis(compute_range, check_axis(None, position), position))
 
     else:
         raise ValueError('Position input should be 1d or 2d.')

--- a/spiketools/tests/spatial/test_occupancy.py
+++ b/spiketools/tests/spatial/test_occupancy.py
@@ -33,6 +33,9 @@ def test_compute_bin_edges():
     position = np.array([[1., 2., 3., 4., 5.], [0., 1., 2., 3., 4.]])
     area_range = [[1, 4], [1, 4]]
 
+    exp_x = np.array([1.0, 2.5, 4.0])
+    exp_y = np.array([1.0, 1.75, 2.5, 3.25, 4.0])
+
     # 2d case with position data
     x_edges, y_edges = compute_bin_edges(position, bins)
     assert [len(x_edges), len(y_edges)] == [bins[0] + 1, bins[1] + 1]
@@ -41,13 +44,18 @@ def test_compute_bin_edges():
 
     # 2d case with area range
     x_edges, y_edges = compute_bin_edges(position, bins, area_range)
-    assert np.array_equal(x_edges, np.array([1.0, 2.5, 4.0]))
-    assert np.array_equal(y_edges, np.array([1.0, 1.75, 2.5, 3.25, 4.0]))
+    assert np.array_equal(x_edges, exp_x)
+    assert np.array_equal(y_edges, exp_y)
 
     # 2d case with no position data (uses area range)
     x_edges, y_edges = compute_bin_edges(None, bins, area_range)
-    assert np.array_equal(x_edges, np.array([1.0, 2.5, 4.0]))
-    assert np.array_equal(y_edges, np.array([1.0, 1.75, 2.5, 3.25, 4.0]))
+    assert np.array_equal(x_edges, exp_x)
+    assert np.array_equal(y_edges, exp_y)
+
+    # Test 2d column data
+    x_edges_c, y_edges_c = compute_bin_edges(position.T, bins, area_range)
+    assert np.array_equal(x_edges_c, exp_x)
+    assert np.array_equal(y_edges_c, exp_y)
 
 def test_compute_bin_assignment():
 
@@ -70,6 +78,11 @@ def test_compute_bin_assignment():
     assert np.array_equal(x_bins, expected1)
     assert np.array_equal(y_bins, expected2)
 
+    # test 2d column data
+    x_bins_c, y_bins_c = compute_bin_assignment(position.T, x_edges, y_edges)
+    assert np.array_equal(x_bins_c, expected1)
+    assert np.array_equal(y_bins_c, expected2)
+
 def test_compute_bin_counts_pos():
 
     # test 1d case
@@ -82,9 +95,13 @@ def test_compute_bin_counts_pos():
     # test 2d case
     pos2d = np.array([[0.5, 1.5, 0.5, 2.5, 1.5], [0.5, 1.5, 0.5, 1.5, 0.5]])
     bins2d = [3, 2]
-    bin_counts = compute_bin_counts_pos(pos2d, bins2d)
-    assert isinstance(bin_counts, np.ndarray)
-    assert np.array_equal(bin_counts, np.array([[2, 1, 0], [0, 1, 1]]))
+    bin_counts_2d = compute_bin_counts_pos(pos2d, bins2d)
+    assert isinstance(bin_counts_2d, np.ndarray)
+    assert np.array_equal(bin_counts_2d, np.array([[2, 1, 0], [0, 1, 1]]))
+
+    # test 2d column data
+    bin_counts_2dc = compute_bin_counts_pos(pos2d.T, bins2d)
+    assert np.array_equal(bin_counts_2dc, np.array([[2, 1, 0], [0, 1, 1]]))
 
 def test_compute_bin_counts_assgn():
 

--- a/spiketools/tests/spatial/test_occupancy.py
+++ b/spiketools/tests/spatial/test_occupancy.py
@@ -33,8 +33,8 @@ def test_compute_bin_edges():
     position = np.array([[1., 2., 3., 4., 5.], [0., 1., 2., 3., 4.]])
     area_range = [[1, 4], [1, 4]]
 
-    exp_x = np.array([1.0, 2.5, 4.0])
-    exp_y = np.array([1.0, 1.75, 2.5, 3.25, 4.0])
+    expected_x = np.array([1.0, 2.5, 4.0])
+    expected_y = np.array([1.0, 1.75, 2.5, 3.25, 4.0])
 
     # 2d case with position data
     x_edges, y_edges = compute_bin_edges(position, bins)
@@ -44,18 +44,18 @@ def test_compute_bin_edges():
 
     # 2d case with area range
     x_edges, y_edges = compute_bin_edges(position, bins, area_range)
-    assert np.array_equal(x_edges, exp_x)
-    assert np.array_equal(y_edges, exp_y)
+    assert np.array_equal(x_edges, expected_x)
+    assert np.array_equal(y_edges, expected_y)
 
     # 2d case with no position data (uses area range)
     x_edges, y_edges = compute_bin_edges(None, bins, area_range)
-    assert np.array_equal(x_edges, exp_x)
-    assert np.array_equal(y_edges, exp_y)
+    assert np.array_equal(x_edges, expected_x)
+    assert np.array_equal(y_edges, expected_y)
 
     # Test 2d column data
     x_edges_c, y_edges_c = compute_bin_edges(position.T, bins, area_range)
-    assert np.array_equal(x_edges_c, exp_x)
-    assert np.array_equal(y_edges_c, exp_y)
+    assert np.array_equal(x_edges_c, expected_x)
+    assert np.array_equal(y_edges_c, expected_y)
 
 def test_compute_bin_assignment():
 

--- a/spiketools/tests/spatial/test_utils.py
+++ b/spiketools/tests/spatial/test_utils.py
@@ -20,11 +20,16 @@ def test_compute_nbins():
 
 def test_compute_pos_ranges():
 
-    positions = np.array([[1, 2, 3, 4, 5], [5, 6, 7, 8, 9]])
-
+    # Test 1d position data
+    positions = np.array([1, 2, 3, 4, 5])
     ranges = compute_pos_ranges(positions)
-    ranges[0] == [1, 5]
-    ranges[1] == [5, 9]
+    assert np.array_equal(ranges, np.array([1, 5]))
+
+    # Test 2d position data
+    positions = np.array([[1, 2, 3, 4, 5], [5, 6, 7, 8, 9]])
+    ranges = compute_pos_ranges(positions)
+    assert np.array_equal(ranges[0], np.array([1, 5]))
+    assert np.array_equal(ranges[1], np.array([5, 9]))
 
 def test_compute_sample_durations():
 

--- a/spiketools/tests/spatial/test_utils.py
+++ b/spiketools/tests/spatial/test_utils.py
@@ -12,18 +12,18 @@ def test_get_position_xy():
     position_2dr = np.array([[1, 2, 3, 4, 5], [5, 6, 7, 8, 9]])
     position_2dc = position_2dr.T
 
-    exp_x = np.array([1, 2, 3, 4, 5])
-    exp_y = np.array([5, 6, 7, 8, 9])
+    expected_x = np.array([1, 2, 3, 4, 5])
+    expected_y = np.array([5, 6, 7, 8, 9])
 
     # Test 2d position data (rows)
     x_data, y_data = get_position_xy(position_2dr)
-    assert np.array_equal(x_data, exp_x)
-    assert np.array_equal(y_data, exp_y)
+    assert np.array_equal(x_data, expected_x)
+    assert np.array_equal(y_data, expected_y)
 
     # Test 2d position data (columns)
     x_data, y_data = get_position_xy(position_2dc)
-    assert np.array_equal(x_data, exp_x)
-    assert np.array_equal(y_data, exp_y)
+    assert np.array_equal(x_data, expected_x)
+    assert np.array_equal(y_data, expected_y)
 
 def test_compute_nbins():
 
@@ -45,18 +45,18 @@ def test_compute_pos_ranges():
 
     # 2d tests
     positions = np.array([[1, 2, 3, 4, 5], [5, 6, 7, 8, 9]])
-    exp1 = np.array([1, 5])
-    exp2 = np.array([5, 9])
+    expected_x = np.array([1, 5])
+    expected_y = np.array([5, 9])
 
     # Test 2d position data (row data)
     ranges_2d = compute_pos_ranges(positions)
-    assert np.array_equal(ranges_2d[0], exp1)
-    assert np.array_equal(ranges_2d[1], exp2)
+    assert np.array_equal(ranges_2d[0], expected_x)
+    assert np.array_equal(ranges_2d[1], expected_y)
 
     # Test 2d position data (column data)
     ranges_2dc = compute_pos_ranges(positions.T)
-    assert np.array_equal(ranges_2dc[0], exp1)
-    assert np.array_equal(ranges_2dc[1], exp2)
+    assert np.array_equal(ranges_2dc[0], expected_x)
+    assert np.array_equal(ranges_2dc[1], expected_y)
 
 def test_compute_sample_durations():
 

--- a/spiketools/tests/spatial/test_utils.py
+++ b/spiketools/tests/spatial/test_utils.py
@@ -43,11 +43,20 @@ def test_compute_pos_ranges():
     ranges = compute_pos_ranges(positions)
     assert np.array_equal(ranges, np.array([1, 5]))
 
-    # Test 2d position data
+    # 2d tests
     positions = np.array([[1, 2, 3, 4, 5], [5, 6, 7, 8, 9]])
-    ranges = compute_pos_ranges(positions)
-    assert np.array_equal(ranges[0], np.array([1, 5]))
-    assert np.array_equal(ranges[1], np.array([5, 9]))
+    exp1 = np.array([1, 5])
+    exp2 = np.array([5, 9])
+
+    # Test 2d position data (row data)
+    ranges_2d = compute_pos_ranges(positions)
+    assert np.array_equal(ranges_2d[0], exp1)
+    assert np.array_equal(ranges_2d[1], exp2)
+
+    # Test 2d position data (column data)
+    ranges_2dc = compute_pos_ranges(positions.T)
+    assert np.array_equal(ranges_2dc[0], exp1)
+    assert np.array_equal(ranges_2dc[1], exp2)
 
 def test_compute_sample_durations():
 

--- a/spiketools/tests/spatial/test_utils.py
+++ b/spiketools/tests/spatial/test_utils.py
@@ -7,6 +7,24 @@ from spiketools.spatial.utils import *
 ###################################################################################################
 ###################################################################################################
 
+def test_get_position_xy():
+
+    position_2dr = np.array([[1, 2, 3, 4, 5], [5, 6, 7, 8, 9]])
+    position_2dc = position_2dr.T
+
+    exp_x = np.array([1, 2, 3, 4, 5])
+    exp_y = np.array([5, 6, 7, 8, 9])
+
+    # Test 2d position data (rows)
+    x_data, y_data = get_position_xy(position_2dr)
+    assert np.array_equal(x_data, exp_x)
+    assert np.array_equal(y_data, exp_y)
+
+    # Test 2d position data (columns)
+    x_data, y_data = get_position_xy(position_2dc)
+    assert np.array_equal(x_data, exp_x)
+    assert np.array_equal(y_data, exp_y)
+
 def test_compute_nbins():
 
     # check 1d case

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -78,6 +78,12 @@ def test_check_array_lst_orientation():
     out2 = check_array_lst_orientation(arr_lst2)
     assert out2 == 'column'
 
+    # Check special cases - empty list and no array with enough elements to infer from
+    sc_1 = check_array_lst_orientation([])
+    assert sc_1 == None
+    sc_2 = check_array_lst_orientation([np.array([[1, 2], [3, 4]])])
+    assert sc_2 == 'row'
+
 def test_check_axis():
 
     arr1d = np.array([1, 2, 3])

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -68,6 +68,19 @@ def test_check_array_orientation():
     arr3c = np.array([[[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4], [5, 6]]])
     assert check_array_orientation(arr3c) == 'column'
 
+def test_check_axis():
+
+    arr1d = np.array([1, 2, 3])
+    arr2dr = np.array([[1, 2, 3], [1, 2, 3]])
+    arr2dc = np.array([[1, 2], [1, 2], [1, 2]])
+
+    assert check_axis(0, arr1d) == 0
+    assert check_axis(1, arr1d) == 1
+    assert check_axis(None, arr1d) == 0
+    assert check_axis(None, arr2dr) == 1
+    assert check_axis(None, arr2dc) == 0
+    assert check_axis(None, arr2dr) == 1
+
 def test_check_bin_range():
 
     values = np.array([0.5, 1.5, 2.5, 3.5, 4.5])

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -99,6 +99,7 @@ def test_check_array_lst_orientation():
 
 def test_check_axis():
 
+    # Test array inputs
     arr1d = np.array([1, 2, 3])
     arr2dr = np.array([[1, 2, 3], [1, 2, 3]])
     arr2dc = np.array([[1, 2], [1, 2], [1, 2]])
@@ -109,6 +110,16 @@ def test_check_axis():
     assert check_axis(None, arr2dr) == 1
     assert check_axis(None, arr2dc) == 0
     assert check_axis(None, arr2dr) == 1
+
+    # Test array list inputs
+    arr_lst_1d = [arr1d, arr1d]
+    arr_lst_2dr = [arr2dr, arr2dr]
+    arr_lst_2dc = [arr2dc, arr2dc]
+    arr_lst_emp = []
+    assert check_axis(None, arr_lst_1d) == 0
+    assert check_axis(None, arr_lst_2dr) == 1
+    assert check_axis(None, arr_lst_2dc) == 0
+    assert check_axis(None, arr_lst_emp) == -1
 
 def test_check_bin_range():
 

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -68,6 +68,16 @@ def test_check_array_orientation():
     arr3c = np.array([[[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4], [5, 6]]])
     assert check_array_orientation(arr3c) == 'column'
 
+def test_check_array_lst_orientation():
+
+    arr_lst1 = [np.array([[], []]), np.array([[1, 2, 4], [5, 6, 7]])]
+    out1 = check_array_lst_orientation(arr_lst1)
+    assert out1 == 'row'
+
+    arr_lst2 = [np.array([[], []]), np.array([[1, 2, 4], [5, 6, 7]]).T]
+    out2 = check_array_lst_orientation(arr_lst2)
+    assert out2 == 'column'
+
 def test_check_axis():
 
     arr1d = np.array([1, 2, 3])

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -63,10 +63,23 @@ def test_check_array_orientation():
     arr2c = np.array([[1, 2], [3, 4], [5, 6]])
     assert check_array_orientation(arr2c) == 'column'
 
+    # Check empty 2d arrays arrays
+    arr2re = arr2re = np.ones((2, 0))
+    assert check_array_orientation(arr2re) == 'row'
+    arr2ce = arr2ce = np.ones((0, 2))
+    assert check_array_orientation(arr2ce) == 'column'
+
+    # Check 3d arrays
     arr3r = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])
     assert check_array_orientation(arr3r) == 'row'
     arr3c = np.array([[[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4], [5, 6]]])
     assert check_array_orientation(arr3c) == 'column'
+
+    # Check empty 2d arrays arrays
+    arr3re = np.ones((1, 2, 0))
+    assert check_array_orientation(arr3re) == 'row'
+    arr3ce = np.ones((1, 0, 2))
+    assert check_array_orientation(arr3ce) == 'column'
 
 def test_check_array_lst_orientation():
 

--- a/spiketools/tests/utils/test_data.py
+++ b/spiketools/tests/utils/test_data.py
@@ -8,6 +8,16 @@ from spiketools.utils.data import _include_bin_edge
 ###################################################################################################
 ###################################################################################################
 
+def test_make_row_orientation():
+
+    arr_r = np.array([[1, 2, 3], [4, 5, 6]])
+    out_r = make_row_orientation(arr_r)
+    assert np.array_equal(out_r, arr_r)
+
+    arr_c = np.array([[1, 4], [2, 5], [3, 6]])
+    out_c = make_row_orientation(arr_c)
+    assert np.array_equal(out_c, arr_r)
+
 def test_compute_range():
 
     data = np.array([0.5, 1., 1.5, 2., 2.5])

--- a/spiketools/tests/utils/test_epoch.py
+++ b/spiketools/tests/utils/test_epoch.py
@@ -53,26 +53,37 @@ def test_epoch_spikes_by_segment():
 def test_epoch_data_by_time():
 
     times = np.array([2.5, 3.5, 4.25, 5.5, 6.1, 8., 9.25, 9.75, 10.5, 12., 14.1, 15.2, 15.9])
-    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
     timepoints = np.array([5, 10, 15])
+
+    # Test 1d array
+    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
     tvalues = epoch_data_by_time(times, values, timepoints)
     assert isinstance(tvalues, list)
     assert len(tvalues) == len(timepoints)
     assert np.array_equal(tvalues, np.array([3, 7, 11]))
 
+    # Test 2d array
+    values_2d = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]])
+    tvalues_2d = epoch_data_by_time(times, values_2d, timepoints)
+    assert tvalues_2d[0].ndim == 1
+
 def test_epoch_data_by_event():
 
     times = np.array([2.5, 3.5, 4.25, 5.5, 6.1, 8., 9.25, 9.75, 10.5, 12., 14.1, 15.2, 15.9])
-    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
     events = np.array([5, 10, 15])
     window = [-1, 1]
+
+    # Test 1d data
+    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
     ttimes, tvalues = epoch_data_by_event(times, values, events, window)
     assert isinstance(ttimes, list)
     assert isinstance(tvalues, list)
     assert isinstance(ttimes[0], np.ndarray)
     assert isinstance(tvalues[0], np.ndarray)
+    assert tvalues[0].ndim == 1
     assert len(ttimes) == len(tvalues) == len(events)
 
     assert np.array_equal(ttimes[0], np.array([4.25, 5.5]) - events[0])
@@ -82,18 +93,27 @@ def test_epoch_data_by_event():
     assert np.array_equal(ttimes[2], np.array([14.1, 15.2, 15.9]) - events[2])
     assert np.array_equal(tvalues[2], np.array([10, 11, 12]))
 
+    # Test 2d data
+    values_2d = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]])
+    ttimes_2d, tvalues_2d = epoch_data_by_event(times, values_2d, events, window)
+    assert tvalues_2d[0].ndim == 2
+
 def test_epoch_data_by_range():
 
     times = np.array([2.5, 3.5, 4.25, 5.5, 6.1, 8., 9.25, 9.75, 10.5, 12., 14.1, 15.2, 15.9])
-    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
     start_times = np.array([5, 12])
     stop_times = np.array([10, 15])
+
+    # Test 1d data
+    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
     ttimes, tvalues = epoch_data_by_range(times, values, start_times, stop_times)
     assert isinstance(ttimes, list)
     assert isinstance(tvalues, list)
     assert isinstance(ttimes[0], np.ndarray)
     assert isinstance(tvalues[0], np.ndarray)
+    assert tvalues[0].ndim == 1
     assert len(ttimes) == len(tvalues) == len(start_times)
 
     assert np.array_equal(ttimes[0], np.array([5.5, 6.1, 8., 9.25, 9.75]))
@@ -108,17 +128,32 @@ def test_epoch_data_by_range():
     assert np.array_equal(ttimes[1], np.array([12.0, 14.1]) - start_times[1])
     assert np.array_equal(tvalues[1], np.array([9, 10]))
 
+    # Test 2d data
+    values_2d = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]])
+    ttimes_2d, tvalues_2d = epoch_data_by_range(times, values_2d, start_times, stop_times)
+    assert tvalues_2d[0].ndim == 2
+
 def test_epoch_data_by_segment():
 
     times = np.array([2.5, 3.5, 4.25, 5.5, 6.1, 8., 9.25, 9.75, 10.5, 12., 14.1, 15.2, 15.9])
-    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
     segments = np.array([2, 5, 10, 15, 20])
+
+    # Test 1d data
+    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
     seg_times, seg_values = epoch_data_by_segment(times, values, segments)
     assert isinstance(seg_times, list)
     assert isinstance(seg_values, list)
     assert isinstance(seg_times[0], np.ndarray)
     assert isinstance(seg_values[0], np.ndarray)
+    assert seg_values[0].ndim == 1
     assert len(seg_times) == len(seg_values) == len(segments) - 1
     assert np.array_equal(seg_times[0], np.array([2.5, 3.5, 4.25]))
     assert np.array_equal(seg_values[0], np.array([0, 1, 2]))
+
+    # Test 2d data
+    values_2d = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]])
+    seg_times_2d, seg_values_2d = epoch_data_by_segment(times, values_2d, segments)
+    assert seg_values_2d[0].ndim == 2

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -15,9 +15,21 @@ def test_create_mask():
     data = np.array([0.5, 1., 1.5, 2., 2.5])
     min_value = 1
     max_value = 2
+    expected = np.array([False, True, True, True, False])
+
     mask = create_mask(data, min_value, max_value)
     assert isinstance(mask, np.ndarray)
-    assert np.array_equal(mask, np.array([False, True, True, True, False]))
+    assert np.array_equal(mask, expected)
+
+    # Test on 2d: row data
+    data_row = np.atleast_2d(data)
+    mask_row = create_mask(data_row, min_value, max_value)
+    assert np.array_equal(mask_row, np.atleast_2d(expected))
+
+    # Test on 2d: column data
+    data_col = data_row.T
+    mask_col = create_mask(data_col, min_value, max_value)
+    assert np.array_equal(mask_col, np.atleast_2d(expected).T)
 
 def test_get_range():
 
@@ -33,7 +45,18 @@ def test_get_range():
     assert np.array_equal(out3, np.array([1., 1.5, 2.]))
 
     out4 = get_range(data, min_value=1., max_value=2., reset=1.)
-    assert np.array_equal(out4, np.array([0., 0.5, 1.0]))
+    expected4 = np.array([0., 0.5, 1.0])
+    assert np.array_equal(out4, expected4)
+
+    # Test on 2d: row data
+    data_row = np.atleast_2d(data)
+    out_row = get_range(data_row, min_value=1., max_value=2., reset=1.)
+    assert np.array_equal(out_row, np.atleast_2d(expected4))
+
+    # Test on 2d: column data
+    data_col = data_row.T
+    out_col = get_range(data_col, min_value=1., max_value=2., reset=1.)
+    assert np.array_equal(out_col, np.atleast_2d(expected4).T)
 
 def test_get_value_range():
 

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -48,16 +48,6 @@ def test_get_range():
     expected4 = np.array([0., 0.5, 1.0])
     assert np.array_equal(out4, expected4)
 
-    # Test on 2d: row data
-    data_row = np.atleast_2d(data)
-    out_row = get_range(data_row, min_value=1., max_value=2., reset=1.)
-    assert np.array_equal(out_row, np.atleast_2d(expected4))
-
-    # Test on 2d: column data
-    data_col = data_row.T
-    out_col = get_range(data_col, min_value=1., max_value=2., reset=1.)
-    assert np.array_equal(out_col, np.atleast_2d(expected4).T)
-
 def test_get_value_range():
 
     times = np.array([1., 2., 3., 4., 5.])

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -107,15 +107,16 @@ def test_get_value_by_time():
 def test_get_values_by_times():
 
     times = np.array([1, 2, 3, 4, 5])
-    values_1d = np.array([5, 8, 4, 6, 7])
-    values_2d = np.array([[5, 8, 4, 6, 7], [5, 8, 4, 6, 7]])
-
     timepoints = np.array([1.75, 4.15])
 
+    # Test 1d extraction
+    values_1d = np.array([5, 8, 4, 6, 7])
     outputs = get_values_by_times(times, values_1d, timepoints)
     assert len(outputs) == len(timepoints)
     assert np.array_equal(outputs, np.array([8, 6]))
 
+    # Test 2d extraction (row data)
+    values_2d = np.array([[5, 8, 4, 6, 7], [5, 8, 4, 6, 7]])
     outputs = get_values_by_times(times, values_2d, timepoints)
     assert len(outputs) == len(timepoints)
     assert np.array_equal(outputs, np.array([[8, 6], [8, 6]]))
@@ -123,11 +124,19 @@ def test_get_values_by_times():
 def test_get_values_by_time_range():
 
     times = np.array([1, 2, 3, 4, 5])
-    values = np.array([5, 8, 4, 6, 7])
 
-    times_out, values_out = get_values_by_time_range(times, values, 2, 4)
-    assert np.array_equal(times_out, np.array([2, 3, 4]))
-    assert np.array_equal(values_out, np.array([8, 4, 6]))
+    # Test 1d extraction
+    values_1d = np.array([5, 8, 4, 6, 7])
+    times_out_1d, values_out_1d = get_values_by_time_range(times, values_1d, 2, 4)
+    assert np.array_equal(times_out_1d, np.array([2, 3, 4]))
+    assert np.array_equal(values_out_1d, np.array([8, 4, 6]))
+
+    # Test 2d extraction (row data)
+    values_2d = np.array([[5, 8, 4, 6, 7],
+                          [5, 8, 4, 6, 7]])
+    times_out_2d, values_out_2d = get_values_by_time_range(times, values_2d, 2, 4)
+    assert np.array_equal(times_out_2d, np.array([2, 3, 4]))
+    assert np.array_equal(values_out_2d, np.array([[8, 4, 6], [8, 4, 6]]))
 
 def test_threshold_spikes_by_times():
 

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -101,8 +101,13 @@ def test_get_value_by_time():
     value_out = get_value_by_time(times, values_1d, 3.4)
     assert value_out == values_1d[2]
 
+    # Test 2d extraction (row data)
     value_out = get_value_by_time(times, values_2d, 3)
     assert np.array_equal(value_out, values_2d[:, 2])
+
+    # Test 2d extraction (column data)
+    value_out = get_value_by_time(times, values_2d.T, 3)
+    assert np.array_equal(value_out, values_2d[:, 2].T)
 
 def test_get_values_by_times():
 
@@ -121,6 +126,11 @@ def test_get_values_by_times():
     assert len(outputs) == len(timepoints)
     assert np.array_equal(outputs, np.array([[8, 6], [8, 6]]))
 
+    # Test 2d extraction (column data)
+    outputs = get_values_by_times(times, values_2d.T, timepoints)
+    assert len(outputs) == len(timepoints)
+    assert np.array_equal(outputs, np.array([[8, 6], [8, 6]]).T)
+
 def test_get_values_by_time_range():
 
     times = np.array([1, 2, 3, 4, 5])
@@ -137,6 +147,11 @@ def test_get_values_by_time_range():
     times_out_2d, values_out_2d = get_values_by_time_range(times, values_2d, 2, 4)
     assert np.array_equal(times_out_2d, np.array([2, 3, 4]))
     assert np.array_equal(values_out_2d, np.array([[8, 4, 6], [8, 4, 6]]))
+
+    # Test 2d extraction (column data)
+    times_out_2d, values_out_2d = get_values_by_time_range(times, values_2d.T, 2, 4)
+    assert np.array_equal(times_out_2d, np.array([2, 3, 4]))
+    assert np.array_equal(values_out_2d, np.array([[8, 4, 6], [8, 4, 6]]).T)
 
 def test_threshold_spikes_by_times():
 

--- a/spiketools/tests/utils/test_trials.py
+++ b/spiketools/tests/utils/test_trials.py
@@ -42,29 +42,29 @@ def test_split_trials_by_condition_array():
 def test_recombine_trial_data():
 
     trial_times = [np.array([1, 2, 3]), np.array([6, 7])]
-    exp_times = np.array([1, 2, 3, 6, 7])
+    expected_times = np.array([1, 2, 3, 6, 7])
 
     # 1d test
     trial_values = [np.array([10, 11, 12]), np.array([1, 2])]
     times_1d, values_1d = recombine_trial_data(trial_times, trial_values)
-    assert np.array_equal(times_1d, exp_times)
+    assert np.array_equal(times_1d, expected_times)
     assert np.array_equal(values_1d, np.array([10, 11, 12, 1, 2]))
 
     # 2d test (row data)
     trial_values_2dr = [np.array([[10, 11, 12], [20, 21, 22]]), np.array([[1, 2], [1, 2]])]
     times_2dr, values_2dr = recombine_trial_data(trial_times, trial_values_2dr)
-    assert np.array_equal(times_2dr, exp_times)
+    assert np.array_equal(times_2dr, expected_times)
     assert np.array_equal(values_2dr, np.array([[10, 11, 12, 1, 2], [20, 21, 22, 1, 2]]))
 
     # 2d test (column data)
     trial_values_2dc = [el.T for el in trial_values_2dr]
     times_2dc, values_2dc = recombine_trial_data(trial_times, trial_values_2dc)
-    assert np.array_equal(times_2dc, exp_times)
+    assert np.array_equal(times_2dc, expected_times)
     assert np.array_equal(values_2dc, np.array([[10, 11, 12, 1, 2], [20, 21, 22, 1, 2]]).T)
 
     # test with empty trials
     trial_times_missing = [np.array([]), np.array([1, 2, 3]), np.array([]), np.array([6, 7])]
     trial_values_missing = [np.array([]), np.array([10, 11, 12]), np.array([]), np.array([1, 2])]
     times_missing, values_missing = recombine_trial_data(trial_times_missing, trial_values_missing)
-    assert np.array_equal(times_missing, exp_times)
+    assert np.array_equal(times_missing, expected_times)
     assert np.array_equal(values_missing, np.array([10, 11, 12, 1, 2]))

--- a/spiketools/tests/utils/test_trials.py
+++ b/spiketools/tests/utils/test_trials.py
@@ -38,3 +38,33 @@ def test_split_trials_by_condition_array():
 
     assert np.array_equal(out['A'], np.array([[1, 2, 3], [4, 5, 6]]))
     assert np.array_equal(out['B'], np.array([[2, 3, 4]]))
+
+def test_recombine_trial_data():
+
+    trial_times = [np.array([1, 2, 3]), np.array([6, 7])]
+    exp_times = np.array([1, 2, 3, 6, 7])
+
+    # 1d test
+    trial_values = [np.array([10, 11, 12]), np.array([1, 2])]
+    times_1d, values_1d = recombine_trial_data(trial_times, trial_values)
+    assert np.array_equal(times_1d, exp_times)
+    assert np.array_equal(values_1d, np.array([10, 11, 12, 1, 2]))
+
+    # 2d test (row data)
+    trial_values_2dr = [np.array([[10, 11, 12], [20, 21, 22]]), np.array([[1, 2], [1, 2]])]
+    times_2dr, values_2dr = recombine_trial_data(trial_times, trial_values_2dr)
+    assert np.array_equal(times_2dr, exp_times)
+    assert np.array_equal(values_2dr, np.array([[10, 11, 12, 1, 2], [20, 21, 22, 1, 2]]))
+
+    # 2d test (column data)
+    trial_values_2dc = [el.T for el in trial_values_2dr]
+    times_2dc, values_2dc = recombine_trial_data(trial_times, trial_values_2dc)
+    assert np.array_equal(times_2dc, exp_times)
+    assert np.array_equal(values_2dc, np.array([[10, 11, 12, 1, 2], [20, 21, 22, 1, 2]]).T)
+
+    # test with empty trials
+    trial_times_missing = [np.array([]), np.array([1, 2, 3]), np.array([]), np.array([6, 7])]
+    trial_values_missing = [np.array([]), np.array([10, 11, 12]), np.array([]), np.array([1, 2])]
+    times_missing, values_missing = recombine_trial_data(trial_times_missing, trial_values_missing)
+    assert np.array_equal(times_missing, exp_times)
+    assert np.array_equal(values_missing, np.array([10, 11, 12, 1, 2]))

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -1,6 +1,7 @@
 """General purpose checker functions."""
 
 import warnings
+from collections import defaultdict
 
 import numpy as np
 
@@ -8,6 +9,8 @@ from spiketools.utils.base import lower_list
 
 ###################################################################################################
 ###################################################################################################
+
+AXISARG = defaultdict(lambda : -1, {'vector' : 0, 'row' : 1, 'column' : 0})
 
 def check_param_range(param, label, bounds):
     """Check a parameter value is within an acceptable range.
@@ -128,8 +131,8 @@ def check_array_orientation(arr):
     -------
     orientation : {'vector', 'row', 'column'}
         The inferred orientation of the data array.
-        For 1d cases, 'vector' indicates data is vector with no directional orientation.
-        For 2d or 3d cases, 'row' or 'column' indicates data is organized row-wise or column-wise respectively.
+        For 1d arrays, 'vector' is returned.
+        For 2d or 3d arrays, 'row' or 'column' is returned based on the shape of the array.
     """
 
     assert arr.ndim < 4, "The check_array_orientation function only works up to 3d."
@@ -139,12 +142,37 @@ def check_array_orientation(arr):
     # This covers 2d or 3d arrays
     else:
         shape = arr.shape
-        if shape[-1] > shape[-2]:
+        # For the ambiguous case of a square shape, 'row' is returned by default
+        if shape[-1] >= shape[-2]:
             orientation = 'row'
         else:
             orientation = 'column'
 
     return orientation
+
+
+def check_axis(axis, arr):
+    """Check axis argument, and infer from array if not defined.
+
+    Parameters
+    ----------
+    axis : {None, -1, 0, 1}
+        Axis argument.
+        If not None, this value is returned.
+        If  None, the given array is checked to infer axis.
+    arr : ndarray
+        Array to check the axis argument for.
+
+    Returns
+    -------
+    axis : {-1, 0, 1}
+        Axis argument.
+    """
+
+    if not axis:
+        axis = AXISARG[check_array_orientation(arr)]
+
+    return axis
 
 
 def check_bin_range(values, bin_area):

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -124,7 +124,7 @@ def check_array_orientation(arr):
 
     Parameters
     ----------
-    arr : 1d or 2d array
+    arr : ndarray
         Data array to check the orientation of.
 
     Returns
@@ -132,33 +132,31 @@ def check_array_orientation(arr):
     orientation : {'vector', 'row', 'column'}
         The inferred orientation of the data array.
         For 1d arrays, 'vector' is returned.
-        For 2d arrays, 'row' or 'column' is returned based on the shape of the array.
+        For 2d or 3rd arrays, 'row' or 'column' is returned based on the shape of the array.
 
     Notes
     -----
-    In arrays with number of elements <= number of dimensions, the orientation can be ambiguous.
+    In cases where # elements > 0 <= # dimensions, orientation can be ambiguous.
     In such cases, 'row' is returned by default.
     """
 
-    assert arr.ndim < 4, "The check_array_orientation function only works up to 2d."
+    assert arr.ndim < 4, "The check_array_orientation function only works up to 3d."
 
     if arr.ndim == 1:
         orientation = 'vector'
 
     else:
 
-        shape = arr.shape
-
         # Special case - empty array, infer based on where zero dimension is
-        if 0 in shape:
-            if shape[-1] == 0:
+        if 0 in arr.shape:
+            if arr.shape[-1] == 0:
                 orientation = 'row'
-            elif shape[-2] == 0:
+            elif arr.shape[-2] == 0:
                 orientation = 'column'
 
         # Otherwise, infer shape based on the relative size of each dimension
         else:
-            if shape[-1] >= shape[-2]:
+            if arr.shape[-1] >= arr.shape[-2]:
                 orientation = 'row'
             else:
                 orientation = 'column'

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -124,7 +124,7 @@ def check_array_orientation(arr):
 
     Parameters
     ----------
-    arr : ndarray
+    arr : 1d or 2d array
         Data array to check the orientation of.
 
     Returns
@@ -132,21 +132,36 @@ def check_array_orientation(arr):
     orientation : {'vector', 'row', 'column'}
         The inferred orientation of the data array.
         For 1d arrays, 'vector' is returned.
-        For 2d or 3d arrays, 'row' or 'column' is returned based on the shape of the array.
+        For 2d arrays, 'row' or 'column' is returned based on the shape of the array.
+
+    Notes
+    -----
+    In arrays with number of elements <= number of dimensions, the orientation can be ambiguous.
+    In such cases, 'row' is returned by default.
     """
 
-    assert arr.ndim < 4, "The check_array_orientation function only works up to 3d."
+    assert arr.ndim < 4, "The check_array_orientation function only works up to 2d."
 
     if arr.ndim == 1:
         orientation = 'vector'
-    # This covers 2d or 3d arrays
+
     else:
+
         shape = arr.shape
-        # For the ambiguous case of a square shape, 'row' is returned by default
-        if shape[-1] >= shape[-2]:
-            orientation = 'row'
+
+        # Special case - empty array, infer based on where zero dimension is
+        if 0 in shape:
+            if shape[-1] == 0:
+                orientation = 'row'
+            elif shape[-2] == 0:
+                orientation = 'column'
+
+        # Otherwise, infer shape based on the relative size of each dimension
         else:
-            orientation = 'column'
+            if shape[-1] >= shape[-2]:
+                orientation = 'row'
+            else:
+                orientation = 'column'
 
     return orientation
 

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -167,14 +167,21 @@ def check_array_lst_orientation(arr_lst):
         For 2d or 3d arrays, 'row' or 'column' is returned based on the shape of the array.
     """
 
-    # Loop over arrays, skipping any with too few elements to infer orientation
-    array = arr_lst[0]
-    for cur_arr in arr_lst:
-        if cur_arr.size > 4:
-            array = cur_arr
-            break
+    # Special case - empty list: return default option
+    if len(arr_lst) == 0:
+        orientation = None
 
-    return check_array_orientation(array)
+    else:
+        # Find an array with enough elements to infer orientation
+        array = arr_lst[0]
+        for cur_arr in arr_lst:
+            if cur_arr.size > 4:
+                array = cur_arr
+                break
+
+        orientation = check_array_orientation(array)
+
+    return orientation
 
 
 def check_axis(axis, arr):

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -151,6 +151,31 @@ def check_array_orientation(arr):
     return orientation
 
 
+def check_array_lst_orientation(arr_lst):
+    """Check the orientation of arrays in a list.
+
+    Parameters
+    ----------
+    arr_lst : list of array
+        List of arrays to check orientation for.
+
+    Returns
+    -------
+    orientation : {'vector', 'row', 'column'}
+        The inferred orientation of the data array.
+        For 1d arrays, 'vector' is returned.
+        For 2d or 3d arrays, 'row' or 'column' is returned based on the shape of the array.
+    """
+
+    # Loop over arrays, skipping any with too few elements to infer orientation
+    for cur_arr in arr_lst:
+        if cur_arr.size > 4:
+            array = cur_arr
+            break
+
+    return check_array_orientation(array)
+
+
 def check_axis(axis, arr):
     """Check axis argument, and infer from array if not defined.
 
@@ -160,7 +185,7 @@ def check_axis(axis, arr):
         Axis argument.
         If not None, this value is returned.
         If  None, the given array is checked to infer axis.
-    arr : ndarray
+    arr : ndarray or list of ndarray
         Array to check the axis argument for.
 
     Returns
@@ -170,7 +195,13 @@ def check_axis(axis, arr):
     """
 
     if not axis:
-        axis = AXISARG[check_array_orientation(arr)]
+
+        if isinstance(arr, list):
+            orientation = check_array_lst_orientation(arr)
+        else:
+            orientation = check_array_orientation(arr)
+
+        axis = AXISARG[orientation]
 
     return axis
 

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -198,22 +198,27 @@ def check_array_lst_orientation(arr_lst):
 
 
 def check_axis(axis, arr):
-    """Check axis argument, and infer from array if not defined.
+    """Check axis argument, and infer from array orientation if not defined.
 
     Parameters
     ----------
-    axis : {None, -1, 0, 1}
+    axis : {None, 0, 1, -1}
         Axis argument.
         If not None, this value is returned.
-        If  None, the given array is checked to infer axis.
+        If None, the given array is checked to infer axis.
     arr : ndarray or list of ndarray
         Array to check the axis argument for.
 
     Returns
     -------
-    axis : {-1, 0, 1}
+    axis : {0, 1, -1}
         Axis argument.
+        For 1d array, 0 is returned, reflecting a vector.
+        For 2d array, 0 is for column, and 1 is for row.
+        If the axis could not be inferred, -1 is returned.
     """
+
+    AXISARG = defaultdict(lambda : -1, {'vector' : 0, 'row' : 1, 'column' : 0})
 
     if not axis:
 

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -168,6 +168,7 @@ def check_array_lst_orientation(arr_lst):
     """
 
     # Loop over arrays, skipping any with too few elements to infer orientation
+    array = arr_lst[0]
     for cur_arr in arr_lst:
         if cur_arr.size > 4:
             array = cur_arr

--- a/spiketools/utils/data.py
+++ b/spiketools/utils/data.py
@@ -6,10 +6,35 @@ import numpy as np
 
 from scipy.ndimage import gaussian_filter
 
-from spiketools.utils.checks import check_param_options, check_bin_range
+from spiketools.utils.checks import check_array_orientation, check_param_options, check_bin_range
 
 ###################################################################################################
 ###################################################################################################
+
+def make_row_orientation(arr, orientation=False):
+    """Check and make sure a 2d array is in row orientation.
+
+    Parameters
+    ----------
+    arr : 2d array
+        Array to check orientation.
+    orientation : {'row', 'column'}, optional
+        The orientation of the input array.
+        If not provided, is inferred from the input data.
+
+    Returns
+    -------
+    arr : 2d array
+        2d array in row orientation.
+    """
+
+    if not orientation:
+        orientation = check_array_orientation(arr)
+
+    arr = arr.T if orientation == 'column' else arr
+
+    return arr
+
 
 def compute_range(data):
     """Compute the range of an array of data.

--- a/spiketools/utils/epoch.py
+++ b/spiketools/utils/epoch.py
@@ -129,7 +129,7 @@ def epoch_data_by_time(timestamps, values, timepoints, threshold=None):
     ----------
     timestamps : 1d array
         Timestamps, in seconds.
-    values : 1d array
+    values : 1d or 2d array
         Data values.
     timepoints : list of float
         The time value(s), in seconds, to extract per trial.
@@ -167,7 +167,7 @@ def epoch_data_by_event(timestamps, values, events, window):
     ----------
     timestamps : 1d array
         Timestamps, in seconds.
-    values : 1d array
+    values : 1d or 2d array
         Data values.
     events : 1d array
         The set of event times to extract from the data.
@@ -211,7 +211,7 @@ def epoch_data_by_range(timestamps, values, start_times, stop_times, reset=False
     ----------
     timestamps : 1d array
         Timestamps, in seconds.
-    values : 1d array
+    values : 1d or 2d array
         Data values, corresponding the the timestamps.
     start_times : list of float
         The start times, in seconds, of each epoch.
@@ -260,7 +260,7 @@ def epoch_data_by_segment(timestamps, values, segments):
     ----------
     timestamps : 1d array
         Timestamps, in seconds.
-    values : 1d array
+    values : 1d or 2d array
         Data values.
     segments : list or 1d array of float
         Time values that define the segments.

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -221,8 +221,8 @@ def get_value_by_time(timestamps, values, timepoint, threshold=None, axis=None):
     threshold : float, optional
         The threshold that the closest time value must be within to be returned.
         If the temporal distance is greater than the threshold, output is NaN.
-    axis : int, optional
-        The axis argument to index the `values` data: 0 for row, 1 for column.
+    axis : {0, 1}, optional
+        The axis argument for the `values` data, if it's a 2d array, as {0: column, 1: row}.
         If not provided, is inferred from the `values` array.
 
     Returns
@@ -263,8 +263,8 @@ def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_nul
     drop_null : bool, optional, default: True
         Whether to drop any null values from the outputs (outside threshold range).
         If False, outputs for any null values are NaN.
-    axis : int, optional
-        The axis argument to index the `values` data: 0 for row, 1 for column.
+    axis : {0, 1}, optional
+        The axis argument for the `values` data, if it's a 2d array, as {0: column, 1: row}.
         If not provided, is inferred from the `values` array.
 
     Returns
@@ -308,8 +308,8 @@ def get_values_by_time_range(timestamps, values, t_min, t_max, axis=None):
         Data values, corresponding to the time values in `timestamps`.
     t_min, t_max : float
         Time range to extract.
-    axis : int, optional
-        The axis argument to index the `values` data: 0 for row, 1 for column.
+    axis : {0, 1}, optional
+        The axis argument for the `values` data, if it's a 2d array, as {0: column, 1: row}.
         If not provided, is inferred from the `values` array.
 
     Returns

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from spiketools.utils.checks import check_axis
 from spiketools.utils.options import get_comp_func
 
 ###################################################################################################
@@ -206,7 +207,7 @@ def get_inds_by_times(timestamps, timepoints, threshold=None, drop_null=True):
     return inds
 
 
-def get_value_by_time(timestamps, values, timepoint, threshold=None):
+def get_value_by_time(timestamps, values, timepoint, threshold=None, axis=None):
     """Get the value from a data array at a specific time point.
 
     Parameters
@@ -220,6 +221,9 @@ def get_value_by_time(timestamps, values, timepoint, threshold=None):
     threshold : float, optional
         The threshold that the closest time value must be within to be returned.
         If the temporal distance is greater than the threshold, output is NaN.
+    axis : int, optional
+        The axis argument to index the `values` data: 0 for row, 1 for column.
+        If not provided, is inferred from the `values` array.
 
     Returns
     -------
@@ -237,12 +241,12 @@ def get_value_by_time(timestamps, values, timepoint, threshold=None):
     """
 
     idx = get_ind_by_time(timestamps, timepoint, threshold=threshold)
-    out = values.take(indices=idx, axis=-1) if idx >= 0 else np.nan
+    out = values.take(indices=idx, axis=check_axis(axis, values)) if idx >= 0 else np.nan
 
     return out
 
 
-def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_null=True):
+def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_null=True, axis=None):
     """Get values from a data array for a set of specified time points.
 
     Parameters
@@ -259,6 +263,9 @@ def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_nul
     drop_null : bool, optional, default: True
         Whether to drop any null values from the outputs (outside threshold range).
         If False, outputs for any null values are NaN.
+    axis : int, optional
+        The axis argument to index the `values` data: 0 for row, 1 for column.
+        If not provided, is inferred from the `values` array.
 
     Returns
     -------
@@ -279,17 +286,18 @@ def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_nul
     inds = get_inds_by_times(timestamps, timepoints, threshold, drop_null)
 
     if drop_null:
-        outputs = values.take(indices=inds, axis=-1)
+        outputs = values.take(indices=inds, axis=check_axis(axis, values))
     else:
         outputs = np.full([np.atleast_2d(values).shape[0], len(timepoints)], np.nan)
         mask = inds >= 0
-        outputs[:, np.where(mask)[0]] = values.take(indices=inds[mask], axis=-1)
+        outputs[:, np.where(mask)[0]] = values.take(indices=inds[mask],
+                                                    axis=check_axis(axis, values))
         outputs = np.squeeze(outputs)
 
     return outputs
 
 
-def get_values_by_time_range(timestamps, values, t_min, t_max):
+def get_values_by_time_range(timestamps, values, t_min, t_max, axis=None):
     """Extract data for a requested time range.
 
     Parameters
@@ -300,6 +308,9 @@ def get_values_by_time_range(timestamps, values, t_min, t_max):
         Data values, corresponding to the time values in `timestamps`.
     t_min, t_max : float
         Time range to extract.
+    axis : int, optional
+        The axis argument to index the `values` data: 0 for row, 1 for column.
+        If not provided, is inferred from the `values` array.
 
     Returns
     -------
@@ -319,7 +330,7 @@ def get_values_by_time_range(timestamps, values, t_min, t_max):
     """
 
     select = np.logical_and(timestamps >= t_min, timestamps <= t_max)
-    out = values.take(indices=np.where(select)[0], axis=-1)
+    out = values.take(indices=np.where(select)[0], axis=check_axis(axis, values))
 
     return timestamps[select], out
 

--- a/spiketools/utils/trials.py
+++ b/spiketools/utils/trials.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from spiketools.utils.checks import check_param_lengths, check_axis
+
 ###################################################################################################
 ###################################################################################################
 
@@ -83,3 +85,32 @@ def split_trials_by_condition_array(trials, conditions):
         out[condition] = trials[np.where(np.array(conditions)==condition)[0], :]
 
     return out
+
+
+def recombine_trial_data(times_trials, values_trials, axis=None):
+    """Recombine data across trials.
+
+    Parameters
+    ----------
+    times_trials : list of 1d array
+        Epoched timestamps.
+    values_trials : list of 1d or 2d array
+        Epoched trial data.
+    axis : {-1, 0, 1}, optional
+        The axis argument to index the `values` data: 0 for row, 1 for column.
+        If not provided, is inferred from the `values_trials` data.
+
+    Returns
+    -------
+    time : 1d array
+        Recombined timestamps.
+    values : 1d or 2d array
+        Recombined trial data.
+    """
+
+    check_param_lengths([times_trials, values_trials], ['times_trials', 'values_trials'])
+
+    times = np.concatenate(times_trials)
+    values = np.concatenate(values_trials, axis=check_axis(axis, values_trials[0]))
+
+    return times, values

--- a/spiketools/utils/trials.py
+++ b/spiketools/utils/trials.py
@@ -96,9 +96,9 @@ def recombine_trial_data(times_trials, values_trials, axis=None):
         Epoched timestamps.
     values_trials : list of 1d or 2d array
         Epoched trial data.
-    axis : {-1, 0, 1}, optional
-        The axis argument to index the `values` data: 0 for row, 1 for column.
-        If not provided, is inferred from the `values_trials` data.
+    axis : {0, 1}, optional
+        The axis argument for the `values` data, if it's a 2d array, as {0: column, 1: row}.
+        If not provided, is inferred from the `values` array.
 
     Returns
     -------


### PR DESCRIPTION
This relates to #141 - and sweeps through procedures that can work on row / column arrays (both general utilities and space-specific functionality), and works through things to allow them to support either row or column organized 2d arrays. 

The general strategy is to try and infer the orientation of the data, and work from there, meaning that these functions should still work as expected (no extra arguments) on row data, but should also work if the data is column organized. This should maintain backwards compatibility, while supporting columnar data, including supporting position data organized in columns. 

In practice, this means that passing in row position data should still work just as it does currently, but also that passing in column-oriented data should work, and provide the same outputs. 