### PR TITLE
[ENH] - Time bins & time definitions for binned spike counts

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -74,6 +74,17 @@ Measures related to trial-epoched data.
    compute_pre_post_averages
    compute_pre_post_diffs
 
+Collections
+~~~~~~~~~~~
+
+Measures that can be applied to collections (groups) of neurons.
+
+.. currentmodule:: spiketools.measures.collections
+.. autosummary::
+   :toctree: generated/
+
+   detect_empty_time_ranges
+
 Objects
 -------
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -31,6 +31,7 @@ Measures for spike data.
    compute_isis
    compute_cv
    compute_fano_factor
+   compute_presence_ratio
 
 Conversions
 ~~~~~~~~~~~
@@ -44,6 +45,7 @@ Conversions between spike representations.
    convert_times_to_train
    convert_train_to_times
    convert_isis_to_times
+   convert_times_to_counts
    convert_times_to_rates
 
 Circular
@@ -485,6 +487,7 @@ Utilities for working with timestamps.
    convert_ms_to_min
    convert_nsamples_to_time
    convert_time_to_nsamples
+   create_bin_times
    split_time_value
    format_time_string
 

--- a/spiketools/measures/collections.py
+++ b/spiketools/measures/collections.py
@@ -8,7 +8,7 @@ from spiketools.measures.spikes import compute_spike_presence
 ###################################################################################################
 ###################################################################################################
 
-def compute_empty_time_ranges(all_spikes, bins, time_range=None):
+def detect_empty_time_ranges(all_spikes, bins, time_range=None):
     """Compute the empty time ranges that are common across a collection of recorded neurons.
 
     Parameters

--- a/spiketools/measures/collections.py
+++ b/spiketools/measures/collections.py
@@ -20,7 +20,7 @@ def detect_empty_time_ranges(all_spikes, bins, time_range=None):
         If float, the time length of each bin.
         If array, precomputed bin definitions.
     time_range : list of [float, float], optional
-        Time range, in seconds, to compute the spike presence across.
+        Time range, in seconds, to use to check for empty time ranges.
         Only used if `bins` is a float.
 
     Returns
@@ -34,6 +34,7 @@ def detect_empty_time_ranges(all_spikes, bins, time_range=None):
 
     return empty_ranges
 
+
 def find_empty_bins(all_spikes, bins, time_range=None):
     """Find empty time bins across a collection of recorded neurons.
 
@@ -46,7 +47,7 @@ def find_empty_bins(all_spikes, bins, time_range=None):
         If float, the time length of each bin.
         If array, precomputed bin definitions.
     time_range : list of [float, float], optional
-        Time range, in seconds, to compute the spike presence across.
+        Time range, in seconds, to use to check for empty time bins.
         Only used if `bins` is a float.
 
     Returns
@@ -58,8 +59,8 @@ def find_empty_bins(all_spikes, bins, time_range=None):
     bins = check_time_bins(bins, time_range)
 
     all_presences = np.full([len(all_spikes), len(bins)-1], False)
-    for ind in range(len(all_spikes)):
-        all_presences[ind, :] = compute_spike_presence(all_spikes[ind], bins)
+    for ind, cur_spikes in enumerate(all_spikes):
+        all_presences[ind, :] = compute_spike_presence(cur_spikes, bins)
 
     bin_emptiness = np.all(~all_presences, 0)
 
@@ -78,7 +79,7 @@ def find_empty_ranges(bin_emptiness, bins, time_range=None):
         If float, the time length of each bin.
         If array, precomputed bin definitions.
     time_range : list of [float, float], optional
-        Time range, in seconds, to compute the empty time ranges across.
+        Time range, in seconds, to use to check for empty time ranges.
         Only used if `bins` is a float.
 
     Returns

--- a/spiketools/measures/collections.py
+++ b/spiketools/measures/collections.py
@@ -1,0 +1,112 @@
+""""Functions to compute measures across collections of recorded neurons."""
+
+import numpy as np
+
+from spiketools.utils.checks import check_time_bins
+from spiketools.measures.spikes import compute_spike_presence
+
+###################################################################################################
+###################################################################################################
+
+def compute_empty_time_ranges(all_spikes, bins, time_range=None):
+    """Compute the empty time ranges that are common across a collection of recorded neurons.
+
+    Parameters
+    ----------
+    all_spikes : list of 1d array
+        Spike times for a collection of neurons.
+    bins : float or 1d array
+        The binning to apply to the spiking data.
+        If float, the time length of each bin.
+        If array, precomputed bin definitions.
+    time_range : list of [float, float], optional
+        Time range, in seconds, to compute the spike presence across.
+        Only used if `bins` is a float.
+
+    Returns
+    -------
+    empty_ranges : list of list of float
+        List of ranges indicating time ranges with no spiking across all neurons.
+    """
+
+    bin_emptiness = find_empty_bins(all_spikes, bins, time_range)
+    empty_ranges = find_empty_ranges(bin_emptiness, bins, time_range)
+
+    return empty_ranges
+
+def find_empty_bins(all_spikes, bins, time_range=None):
+    """Find empty time bins across a collection of recorded neurons.
+
+    Parameters
+    ----------
+    all_spikes : list of 1d array
+        Spike times for a collection of neurons.
+    bins : float or 1d array
+        The binning to apply to the spiking data.
+        If float, the time length of each bin.
+        If array, precomputed bin definitions.
+    time_range : list of [float, float], optional
+        Time range, in seconds, to compute the spike presence across.
+        Only used if `bins` is a float.
+
+    Returns
+    -------
+    bin_emptiness : 1d array
+        Boolean array indicating which bins are empty across all neurons.
+    """
+
+    bins = check_time_bins(bins, time_range)
+
+    all_presences = np.full([len(all_spikes), len(bins)-1], False)
+    for ind in range(len(all_spikes)):
+        all_presences[ind, :] = compute_spike_presence(all_spikes[ind], bins)
+
+    bin_emptiness = np.all(~all_presences, 0)
+
+    return bin_emptiness
+
+
+def find_empty_ranges(bin_emptiness, bins, time_range=None):
+    """Find empty time ranges based on time bin emptiness for a collection of recorded neurons.
+
+    Parameters
+    ----------
+    bin_emptiness : 1d array
+        Boolean array indicating which bins are empty across all neurons.
+    bins : float or 1d array
+        The binning to apply to the spiking data.
+        If float, the time length of each bin.
+        If array, precomputed bin definitions.
+    time_range : list of [float, float], optional
+        Time range, in seconds, to compute the empty time ranges across.
+        Only used if `bins` is a float.
+
+    Returns
+    -------
+    empty_ranges : list of list of float
+        List of ranges indicating time ranges with no spiking across all neurons.
+    """
+
+    bins = check_time_bins(bins, time_range)
+
+    diff_inds = np.where(np.diff(bin_emptiness))[0] + 1
+
+    empty_ranges = []
+
+    # Special case: first bin is empty
+    if bin_emptiness[0] == True:
+        empty_ranges.append([bins[0], bins[diff_inds[0]]])
+        diff_inds = np.delete(diff_inds, 0)
+
+    # Special case: last bin is empty
+    if bin_emptiness[-1] == True:
+        empty_ranges.append([bins[diff_inds[-1]], bins[-1]])
+        diff_inds = np.delete(diff_inds, -1)
+
+    # Over empty regions can be found be stepping across pairs of diffs (changes)
+    diff_inds_2d = np.reshape(diff_inds, [int(len(diff_inds) / 2), 2])
+    empty_ranges.extend([[bins[inds[0]], bins[inds[1]]] for inds in diff_inds_2d])
+
+    empty_ranges.sort(key=lambda x: x[0])
+
+    return empty_ranges

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -185,7 +185,8 @@ def convert_times_to_rates(spikes, bins, time_range=None, smooth=None):
     """
 
     bins = check_time_bins(bins, spikes, time_range)
-    bin_counts, _ = np.histogram(spikes, bins)
+    bin_counts = convert_times_to_counts(spikes, bins, time_range)
+
     cfr = bin_counts / np.diff(bins)
 
     if smooth:

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -118,6 +118,41 @@ def convert_isis_to_times(isis, offset=0, add_offset=True):
     return spikes
 
 
+def convert_times_to_counts(spikes, bins, time_range=None):
+    """Compute spikes times to counts of spikes per time bin.
+
+    Parameters
+    ----------
+    spikes : 1d array
+        Spike times, in seconds.
+    bins : float or 1d array
+        The binning to apply to the spiking data.
+        If float, the length of each bin.
+        If array, precomputed bin definitions.
+    time_range : list of [float, float], optional
+        Time range, in seconds, to create the binned firing rate across.
+        Only used if `bins` is a float.
+
+    Returns
+    -------
+    spike_bin_counts : 1d array
+        Vector of counts of the number of spikes per time bin.
+
+    Examples
+    --------
+    Convert spike times (in seconds) to counts of spikes per time bin:
+
+    >>> spikes = np.array([0.100, 0.350, 0.450, 0.775, 0.975])
+    >>> convert_times_to_counts(spikes, bins=0.250)
+    array([1, 2, 0, 2])
+    """
+
+    bins = check_time_bins(bins, spikes, time_range)
+    spike_bin_counts, _ = np.histogram(spikes, bins)
+
+    return spike_bin_counts
+
+
 def convert_times_to_rates(spikes, bins, time_range=None, smooth=None):
     """Convert spike times to continuous firing rate.
 

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -127,10 +127,10 @@ def convert_times_to_counts(spikes, bins, time_range=None):
         Spike times, in seconds.
     bins : float or 1d array
         The binning to apply to the spiking data.
-        If float, the length of each bin.
+        If float, the time length of each bin.
         If array, precomputed bin definitions.
     time_range : list of [float, float], optional
-        Time range, in seconds, to create the binned firing rate across.
+        Time range, in seconds, to calculate the spike counts across.
         Only used if `bins` is a float.
 
     Returns
@@ -162,10 +162,10 @@ def convert_times_to_rates(spikes, bins, time_range=None, smooth=None):
         Spike times, in seconds.
     bins : float or 1d array
         The binning to apply to the spiking data.
-        If float, the length of each bin.
+        If float, the time length of each bin.
         If array, precomputed bin definitions.
     time_range : list of [float, float], optional
-        Time range, in seconds, to create the binned firing rate across.
+        Time range, in seconds, to calculate the binned firing rate across.
         Only used if `bins` is a float.
     smooth : float, optional
         If provided, the kernel to use to smooth the continuous firing rate.

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -147,7 +147,7 @@ def convert_times_to_counts(spikes, bins, time_range=None):
     array([1, 2, 0, 2])
     """
 
-    bins = check_time_bins(bins, spikes, time_range)
+    bins = check_time_bins(bins, time_range, spikes)
     spike_bin_counts, _ = np.histogram(spikes, bins)
 
     return spike_bin_counts
@@ -184,7 +184,7 @@ def convert_times_to_rates(spikes, bins, time_range=None, smooth=None):
     array([ 5.,  5., 10.,  5.,  0.,  5., 15.,  5.])
     """
 
-    bins = check_time_bins(bins, spikes, time_range)
+    bins = check_time_bins(bins, time_range, spikes)
     bin_counts = convert_times_to_counts(spikes, bins, time_range)
 
     cfr = bin_counts / np.diff(bins)

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -119,7 +119,7 @@ def convert_isis_to_times(isis, offset=0, add_offset=True):
 
 
 def convert_times_to_counts(spikes, bins, time_range=None):
-    """Compute spikes times to counts of spikes per time bin.
+    """Convert spikes times to counts of spikes per time bin.
 
     Parameters
     ----------

--- a/spiketools/measures/spikes.py
+++ b/spiketools/measures/spikes.py
@@ -127,10 +127,10 @@ def compute_spike_presence(spikes, bins, time_range=None):
         Spike times, in seconds.
     bins : float or 1d array
         The binning to apply to the spiking data.
-        If float, the length of each bin.
+        If float, the time length of each bin.
         If array, precomputed bin definitions.
     time_range : list of [float, float], optional
-        Time range, in seconds, to create the binned firing rate across.
+        Time range, in seconds, to calculate the spike presence across.
         Only used if `bins` is a float.
 
     Returns
@@ -154,10 +154,10 @@ def compute_presence_ratio(spikes, bins, time_range=None):
         Spike times, in seconds.
     bins : float or 1d array
         The binning to apply to the spiking data.
-        If float, the length of each bin.
+        If float, the time length of each bin.
         If array, precomputed bin definitions.
     time_range : list of [float, float], optional
-        Time range, in seconds, to create the binned firing rate across.
+        Time range, in seconds, to calculate the presence ratio across.
         Only used if `bins` is a float.
 
     Returns

--- a/spiketools/measures/spikes.py
+++ b/spiketools/measures/spikes.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from spiketools.utils.extract import get_range
+from spiketools.measures.conversions import convert_times_to_counts
 
 ###################################################################################################
 ###################################################################################################
@@ -115,3 +116,34 @@ def compute_fano_factor(spike_train):
     """
 
     return np.var(spike_train) / np.mean(spike_train)
+
+
+def compute_presence_ratio(spikes, bins, time_range=None):
+    """Compute the presence ratio for a set of spike times.
+
+    Parameters
+    ----------
+    spikes : 1d array
+        Spike times, in seconds.
+    bins : float or 1d array
+        The binning to apply to the spiking data.
+        If float, the length of each bin.
+        If array, precomputed bin definitions.
+    time_range : list of [float, float], optional
+        Time range, in seconds, to create the binned firing rate across.
+        Only used if `bins` is a float.
+
+    Returns
+    -------
+    presence_ratio : float
+        The computed presence ratio.
+
+    Notes
+    -----
+    The presence ratio reflects the proportion of time bins in which at least 1 spike occurred.
+    """
+
+    spike_bin_counts = convert_times_to_counts(spikes, bins, time_range)
+    presence_ratio = sum(spike_bin_counts != 0) / len(spike_bin_counts)
+
+    return presence_ratio

--- a/spiketools/measures/spikes.py
+++ b/spiketools/measures/spikes.py
@@ -118,6 +118,33 @@ def compute_fano_factor(spike_train):
     return np.var(spike_train) / np.mean(spike_train)
 
 
+def compute_spike_presence(spikes, bins, time_range=None):
+    """Compute the spike presence across time bins.
+
+    Parameters
+    ----------
+    spikes : 1d array
+        Spike times, in seconds.
+    bins : float or 1d array
+        The binning to apply to the spiking data.
+        If float, the length of each bin.
+        If array, precomputed bin definitions.
+    time_range : list of [float, float], optional
+        Time range, in seconds, to create the binned firing rate across.
+        Only used if `bins` is a float.
+
+    Returns
+    -------
+    spike_presence : 1d array
+        Boolean array indicating spike presence across time bins.
+    """
+
+    spike_counts = convert_times_to_counts(spikes, bins, time_range)
+    spike_presence = spike_counts != 0
+
+    return spike_presence
+
+
 def compute_presence_ratio(spikes, bins, time_range=None):
     """Compute the presence ratio for a set of spike times.
 
@@ -143,7 +170,7 @@ def compute_presence_ratio(spikes, bins, time_range=None):
     The presence ratio reflects the proportion of time bins in which at least 1 spike occurred.
     """
 
-    spike_bin_counts = convert_times_to_counts(spikes, bins, time_range)
-    presence_ratio = sum(spike_bin_counts != 0) / len(spike_bin_counts)
+    spike_presence = compute_spike_presence(spikes, bins, time_range)
+    presence_ratio = sum(spike_presence) / len(spike_presence)
 
     return presence_ratio

--- a/spiketools/measures/trials.py
+++ b/spiketools/measures/trials.py
@@ -52,7 +52,7 @@ def compute_trial_frs(trial_spikes, bins, time_range=None, smooth=None):
            [4., 4.]])
     """
 
-    bins = check_time_bins(bins, trial_spikes[0], time_range=time_range)
+    bins = check_time_bins(bins, time_range)
     bin_times = create_bin_times(bins)
 
     trial_cfrs = np.zeros([len(trial_spikes), len(bin_times)])

--- a/spiketools/measures/trials.py
+++ b/spiketools/measures/trials.py
@@ -5,6 +5,7 @@ import numpy as np
 from spiketools.utils.extract import get_range
 from spiketools.utils.options import get_avg_func
 from spiketools.utils.checks import check_time_bins
+from spiketools.utils.timestamps import create_bin_times
 from spiketools.measures.spikes import compute_firing_rate
 from spiketools.measures.conversions import convert_times_to_rates
 
@@ -30,6 +31,8 @@ def compute_trial_frs(trial_spikes, bins, time_range=None, smooth=None):
 
     Returns
     -------
+    bin_times : 1d array
+        Timestamps for the computed time bins.
     trial_cfrs : 2d array
         Continuous firing rates per trial, with shape [n_trials, n_time_bins].
 
@@ -42,18 +45,21 @@ def compute_trial_frs(trial_spikes, bins, time_range=None, smooth=None):
                         np.array([0.250, 0.350, 0.700, 0.900])]
     >>> bins = 0.5
     >>> time_range = [0.0, 1.0]
-    >>> compute_trial_frs(trial_spikes, bins, time_range)
+    >>> bin_times, trial_cfrs = compute_trial_frs(trial_spikes, bins, time_range)
+    >>> trial_cfrs
     array([[6., 0.],
            [8., 2.],
            [4., 4.]])
     """
 
     bins = check_time_bins(bins, trial_spikes[0], time_range=time_range)
-    trial_cfrs = np.zeros([len(trial_spikes), len(bins) - 1])
+    bin_times = create_bin_times(bins)
+
+    trial_cfrs = np.zeros([len(trial_spikes), len(bin_times)])
     for ind, t_spikes in enumerate(trial_spikes):
         trial_cfrs[ind, :] = convert_times_to_rates(t_spikes, bins, smooth)
 
-    return trial_cfrs
+    return bin_times, trial_cfrs
 
 
 def compute_pre_post_rates(trial_spikes, pre_window, post_window):

--- a/spiketools/tests/measures/test_collections.py
+++ b/spiketools/tests/measures/test_collections.py
@@ -7,11 +7,11 @@ from spiketools.measures.collections import *
 ###################################################################################################
 ###################################################################################################
 
-def test_compute_empty_time_ranges():
+def test_detect_empty_time_ranges():
 
     all_spikes = [np.array([0.5, 1.1, 1.9, 4.1]),
                   np.array([1.5, 2.5, 4.25])]
-    empty_ranges = compute_empty_time_ranges(all_spikes, 1, [0, 5])
+    empty_ranges = detect_empty_time_ranges(all_spikes, 1, [0, 5])
     assert empty_ranges == [[3, 4]]
 
 

--- a/spiketools/tests/measures/test_collections.py
+++ b/spiketools/tests/measures/test_collections.py
@@ -1,0 +1,41 @@
+"""Tests for spiketools.measures.all"""
+
+import numpy as np
+
+from spiketools.measures.collections import *
+
+###################################################################################################
+###################################################################################################
+
+def test_compute_empty_time_ranges():
+
+    all_spikes = [np.array([0.5, 1.1, 1.9, 4.1]),
+                  np.array([1.5, 2.5, 4.25])]
+    empty_ranges = compute_empty_time_ranges(all_spikes, 1, [0, 5])
+    assert empty_ranges == [[3, 4]]
+
+
+def test_find_empty_bins():
+
+    all_spikes = [np.array([0.5, 1.1, 1.9, 4.1]),
+                  np.array([1.5, 2.5, 4.25])]
+
+    empty_bins = find_empty_bins(all_spikes, 1, [0, 5])
+    assert isinstance(empty_bins, np.ndarray)
+    assert empty_bins.dtype == 'bool'
+    assert np.array_equal(empty_bins, np.array([False, False, False, True, False]))
+
+def test_find_empty_ranges():
+
+    empty_bins = np.array([False, False, False, True, False])
+    empty_ranges = find_empty_ranges(empty_bins, 1, [0, 5])
+    assert empty_ranges == [[3, 4]]
+
+    empty_bins = np.array([False, True, True, False, False, False, True, True, False, False])
+    empty_ranges = find_empty_ranges(empty_bins, 0.5, [0, 5])
+    assert empty_ranges == [[0.5, 1.5], [3.0, 4.0]]
+
+    # Test case with empty ranges at beginning and end
+    empty_bins = np.array([True, True, False, False, False, True, True, False, False, True])
+    empty_ranges = find_empty_ranges(empty_bins, 0.5, [0, 5])
+    assert empty_ranges == [[0., 1.], [2.5, 3.5], [4.5, 5]]

--- a/spiketools/tests/measures/test_conversions.py
+++ b/spiketools/tests/measures/test_conversions.py
@@ -58,6 +58,18 @@ def test_convert_isis_to_times(tspikes):
     spikes4 = convert_isis_to_times(isis, offset=tspikes[0])
     assert np.array_equal(spikes4, tspikes)
 
+def test_convert_times_to_counts(tspikes):
+
+    bins = np.arange(0, 10, 1)
+    counts = convert_times_to_counts(tspikes, bins)
+    assert isinstance(counts, np.ndarray)
+    assert len(counts) == len(bins) - 1
+
+    # Check example with exact output check
+    spikes = np.array([0.1, 0.3, 0.4, 0.775, 0.825, 0.900])
+    counts = convert_times_to_counts(spikes, 0.250)
+    assert np.array_equal(counts, np.array([1, 2, 0, 3]))
+
 def test_convert_times_to_rates(tspikes):
 
     # Using precomputed bin definition

--- a/spiketools/tests/measures/test_spikes.py
+++ b/spiketools/tests/measures/test_spikes.py
@@ -49,6 +49,17 @@ def test_compute_fano_factor():
     assert isinstance(fano2, float)
     assert fano2 < 1
 
+def test_compute_spike_presence(tspikes):
+
+    tspike_presence = compute_spike_presence(tspikes, 0.5, [0, 10])
+    assert isinstance(tspike_presence, np.ndarray)
+    assert tspike_presence.dtype == 'bool'
+
+    spikes = np.array([1.1, 1.75, 2.25, 2.9])
+    bins = np.array([0, 1, 2, 3, 4, 5])
+    spike_presence = compute_spike_presence(spikes, bins)
+    assert np.array_equal(spike_presence, np.array([False, True, True, False, False]))
+
 def test_compute_presence_ratio():
 
     spikes1 = np.array([0.1, 0.3, 0.4, 0.775, 0.825, 0.900])

--- a/spiketools/tests/measures/test_spikes.py
+++ b/spiketools/tests/measures/test_spikes.py
@@ -48,3 +48,13 @@ def test_compute_fano_factor():
     fano2 = compute_fano_factor(spike_train2)
     assert isinstance(fano2, float)
     assert fano2 < 1
+
+def test_compute_presence_ratio():
+
+    spikes1 = np.array([0.1, 0.3, 0.4, 0.775, 0.825, 0.900])
+    presence_ratio1 = compute_presence_ratio(spikes1, 0.250)
+    assert presence_ratio1 == 0.75
+
+    spikes2 = np.array([0.05, 0.15])
+    presence_ratio2 = compute_presence_ratio(spikes2, np.arange(0, 1.1, 0.1))
+    assert presence_ratio2 == 0.2

--- a/spiketools/tests/measures/test_trials.py
+++ b/spiketools/tests/measures/test_trials.py
@@ -11,9 +11,9 @@ def test_compute_trial_frs(ttrial_spikes):
 
     trial_spikes = [ttrial_spikes, ttrial_spikes]
     bins = np.arange(-1, 1 + 0.25, 0.25)
-    out = compute_trial_frs(trial_spikes, bins)
-    assert isinstance(out, np.ndarray)
-    assert out.shape == (len(trial_spikes), len(bins) - 1)
+    bin_times, trial_frs = compute_trial_frs(trial_spikes, bins)
+    assert isinstance(trial_frs, np.ndarray)
+    assert trial_frs.shape == (len(trial_spikes), len(bins) - 1)
 
 def test_compute_pre_post_rates(ttrial_spikes):
 

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -97,3 +97,7 @@ def test_check_time_bins(tspikes):
         out = check_time_bins(np.array([1, 2, 1]), tspikes, time_range=[0, 5])
     with warns(UserWarning):
         out = check_time_bins(0.5, tspikes, time_range=[0, 5])
+
+    # Test bin definition with no values provided
+    tbins = check_time_bins(0.5, None, [0, 5])
+    assert np.array_equal(tbins, np.arange(0, 5.5, 0.5))

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -94,9 +94,9 @@ def test_check_time_bins(tspikes):
 
     # Check error & warning
     with raises(AssertionError):
-        out = check_time_bins(np.array([1, 2, 1]), [0, 5], tspikes)
+        out = check_time_bins(np.array([1, 2, 1]), [0, 5], tspikes, True)
     with warns(UserWarning):
-        out = check_time_bins(0.5, [0, 5], tspikes)
+        out = check_time_bins(0.5, [0, 5], tspikes, True)
 
     # Test bin definition with no values provided
     tbins = check_time_bins(0.5, [0, 5])

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -85,19 +85,19 @@ def test_check_time_bins(tspikes):
 
     # Check precomputed time bins
     tbins = np.arange(0, 10 + 0.5, 0.5)
-    out = check_time_bins(tbins, tspikes)
+    out = check_time_bins(tbins, None, tspikes)
     assert np.array_equal(tbins, out)
 
     # Check time bins given a time resolution, which should create same bins as precomputed
-    out = check_time_bins(0.5, tspikes, time_range=[0, 10])
+    out = check_time_bins(0.5, [0, 10], tspikes)
     assert np.array_equal(tbins, out)
 
     # Check error & warning
     with raises(AssertionError):
-        out = check_time_bins(np.array([1, 2, 1]), tspikes, time_range=[0, 5])
+        out = check_time_bins(np.array([1, 2, 1]), [0, 5], tspikes)
     with warns(UserWarning):
-        out = check_time_bins(0.5, tspikes, time_range=[0, 5])
+        out = check_time_bins(0.5, [0, 5], tspikes)
 
     # Test bin definition with no values provided
-    tbins = check_time_bins(0.5, None, [0, 5])
+    tbins = check_time_bins(0.5, [0, 5])
     assert np.array_equal(tbins, np.arange(0, 5.5, 0.5))

--- a/spiketools/tests/utils/test_timestamps.py
+++ b/spiketools/tests/utils/test_timestamps.py
@@ -75,6 +75,23 @@ def test_convert_time_to_nsamples():
     assert isinstance(out, int)
     assert out == 12
 
+def test_create_bin_times():
+
+    # Check basic time bin definition
+    bins1 = np.array([0, 0.5, 1.0, 1.5, 2.0])
+    out1 = create_bin_times(bins1)
+    assert np.array_equal(out1, np.array([0.25, 0.75, 1.25, 1.75]))
+
+    # Check bin definition that doesn't start at zero
+    bins2 = np.array([-1.0, -0.5, 0, 0.5, 1.0])
+    out2 = create_bin_times(bins2)
+    assert np.array_equal(out2, np.array([-0.75, -0.25, 0.25, 0.75]))
+
+    # Check uneven bin definition
+    bins2 = np.array([0, 0.5, 1.0, 2.0])
+    out3 = create_bin_times(bins2)
+    assert np.array_equal(out3, np.array([0.25, 0.75, 1.5]))
+
 def test_split_time_value():
 
     value = 3600 + 1800 + 30

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -130,7 +130,7 @@ def check_array_orientation(arr):
     orientation : {'vector', 'row', 'column'}
         The inferred orientation of the data array.
         For 1d cases, 'vector' indicates data is vector with no directional orientation.
-        For 2d or 3d cases, 'row' or 'column' indicates data is organized row-wise or column-wise respectively.
+        For 2d or 3d cases, 'row' or 'column' indicates it's a row-wise / column-wise data array.
     """
 
     assert arr.ndim < 4, "The check_array_orientation function only works up to 3d."

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -165,7 +165,7 @@ def check_bin_range(values, bin_area):
             warnings.warn(msg)
 
 
-def check_time_bins(bins, time_range=None, values=None, check_range=True):
+def check_time_bins(bins, time_range=None, values=None, check_range=False):
     """Check a given time bin definition, and define if only given a time resolution.
 
     Parameters
@@ -180,7 +180,7 @@ def check_time_bins(bins, time_range=None, values=None, check_range=True):
     values : 1d array, optional
         The time values that are to be binned.
         Optional if time range is provided instead.
-    check_range : bool, optional, default: True
+    check_range : bool, optional, default: False
         Whether to check the range of the data values against the time bins.
 
     Returns

--- a/spiketools/utils/checks.py
+++ b/spiketools/utils/checks.py
@@ -165,7 +165,7 @@ def check_bin_range(values, bin_area):
             warnings.warn(msg)
 
 
-def check_time_bins(bins, values=None, time_range=None, check_range=True):
+def check_time_bins(bins, time_range=None, values=None, check_range=True):
     """Check a given time bin definition, and define if only given a time resolution.
 
     Parameters
@@ -174,14 +174,14 @@ def check_time_bins(bins, values=None, time_range=None, check_range=True):
         The binning to apply to the spiking data.
         If float, the length of each bin.
         If array, precomputed bin definitions.
-    values : 1d array, optional
-        The time values that are to be binned.
-        Optional if time range is provided instead.
     time_range : list of [float, float], optional
         Time range, in seconds, to create the binned firing rate across.
         Only used if `bins` is a float. If given, the end value is inclusive.
-    check_range : True
-        Whether the check the range of the data values against the time bins.
+    values : 1d array, optional
+        The time values that are to be binned.
+        Optional if time range is provided instead.
+    check_range : bool, optional, default: True
+        Whether to check the range of the data values against the time bins.
 
     Returns
     -------
@@ -195,13 +195,13 @@ def check_time_bins(bins, values=None, time_range=None, check_range=True):
     >>> bins = 0.5
     >>> values = np.array([0.2, 0.4, 0.6, 0.9, 1.4, 1.5, 1.6, 1.9])
     >>> time_range = [0., 2.]
-    >>> check_time_bins(bins, values, time_range)
+    >>> check_time_bins(bins, time_range, values)
     array([0. , 0.5, 1. , 1.5, 2. ])
 
     Check a time bin definition, where bins are already defined:
 
     >>> bins = np.array([0. , 0.5, 1. , 1.5, 2. ])
-    >>> check_time_bins(bins, values, time_range)
+    >>> check_time_bins(bins, time_range, values)
     array([0. , 0.5, 1. , 1.5, 2. ])
     """
 

--- a/spiketools/utils/timestamps.py
+++ b/spiketools/utils/timestamps.py
@@ -196,6 +196,30 @@ def convert_time_to_nsamples(time, fs):
     return n_samples
 
 
+def create_bin_times(bins):
+    """Create a timepoints definitions for a set of time bins.
+
+    Parameters
+    ----------
+    bins : 1d array
+        Time bins.
+
+    Returns
+    -------
+    bin_times : 1d array
+        Time values corresponding to the bin definition.
+
+    Notes
+    -----
+    The bin timepoints are defined as the center point of each bin.
+    This function works for evenly spaced and uneven bin definitions.
+    """
+
+    bin_times = bins[:-1] + np.diff(bins) / 2
+
+    return bin_times
+
+
 def split_time_value(sec):
     """Split a time value from seconds to hours / minutes / seconds.
 


### PR DESCRIPTION
Responds to #150, plus some related extensions.

This PR re-organizes and extends some of the functionality related to compute continuous firing rates. Related to the original point, it adds the `create_bin_times` function to define the timestamps related to a time definition, and computes and returns these from `compute_trial_frs`, so they are available and can be used for plotting. 

Additional updates:
- adds the `compute_presence_ratio` function
- refactors convert functions to split out converting to counts vs converting to frs