### PR TITLE
[ENH/MNT] - Miscellaneous updates / fixes

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -498,11 +498,8 @@ Utilities for working with timestamps.
    convert_ms_to_min
    convert_nsamples_to_time
    convert_time_to_nsamples
-<<<<<<< HEAD
    sum_time_ranges
-=======
    create_bin_times
->>>>>>> main
    split_time_value
    format_time_string
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -485,6 +485,7 @@ Utilities for working with timestamps.
    convert_ms_to_min
    convert_nsamples_to_time
    convert_time_to_nsamples
+   sum_time_ranges
    split_time_value
    format_time_string
 

--- a/spiketools/measures/spikes.py
+++ b/spiketools/measures/spikes.py
@@ -7,15 +7,15 @@ from spiketools.utils.extract import get_range
 ###################################################################################################
 ###################################################################################################
 
-def compute_firing_rate(spikes, start_time=None, stop_time=None):
+def compute_firing_rate(spikes, time_range=None):
     """Estimate firing rate from a vector of spike times, in seconds.
 
     Parameters
     ----------
     spikes : 1d array
         Spike times, in seconds.
-    start_time, stop_time : float, optional
-        Start and stop time of the range to compute the firing rate over.
+    time_range : list of [float, float], optional
+        Time range, in seconds, to calculate the firing rate across.
 
     Returns
     -------
@@ -31,11 +31,11 @@ def compute_firing_rate(spikes, start_time=None, stop_time=None):
     2.4
     """
 
-    if start_time or stop_time:
-        spikes = get_range(spikes, start_time, stop_time)
+    if time_range:
+        spikes = get_range(spikes, time_range[0], time_range[1])
 
-    start_time = spikes[0] if start_time is None else start_time
-    stop_time = spikes[-1] if stop_time is None else stop_time
+    start_time = spikes[0] if time_range is None else time_range[0]
+    stop_time = spikes[-1] if time_range is None else time_range[1]
 
     fr = len(spikes) / (stop_time - start_time)
 

--- a/spiketools/measures/trials.py
+++ b/spiketools/measures/trials.py
@@ -80,7 +80,7 @@ def compute_pre_post_rates(trial_spikes, pre_window, post_window):
                         np.array([0.550, 0.650, 0.70, 0.9, 0.950])]
     >>> pre_window, post_window = [-0.5, 0.0], [0.5, 0.9]
     >>> compute_pre_post_rates(trial_spikes, pre_window, post_window)
-    (array([6., 2., 0.]), array([ 2.5,  2.5, 10. ]))
+    (array([6., 2., 0.]), array([2.5, 2.5, 7.5]))
     """
 
     frs_pre = np.array([compute_firing_rate(trial, pre_window) for trial in trial_spikes])
@@ -109,16 +109,16 @@ def compute_segment_frs(spikes, segments):
     --------
     Compute firing rate across segments, with custom segment times per trial:
 
-    >>> spikes = [np.array([0.002, 0.005, 0.120, 0.150, 0.250]), \
-                  np.array([0.275, 0.290, 0.3, 0.350, 0.5]), \
-                  np.array([0.550, 0.650, 0.70, 0.9, 0.950])]
-    >>> segments = np.array([[0, 0.1, 0.15, 0.26], \
-                             [0.27, 0.35, 0.4, 0.51], \
-                             [0.52, 0.7, 0.9, 1]])
+    >>> spikes = [np.array([0.002, 0.005, 0.120, 0.175, 0.250]), \
+                  np.array([0.275, 0.290, 0.300, 0.350, 0.500]), \
+                  np.array([0.550, 0.650, 0.700, 0.950])]
+    >>> segments = np.array([[0.00, 0.15, 0.25], \
+                             [0.20, 0.40, 0.60], \
+                             [0.50, 0.70, 0.90]])
     >>> compute_segment_frs(spikes, segments)
-    array([[20.        , 20.        , 18.18181818],
-           [37.5       , 20.        ,  9.09090909],
-           [11.11111111,  5.        , 20.        ]])
+    array([[20., 20.],
+           [20.,  5.],
+           [10.,  5.]])
     """
 
     if not isinstance(spikes, list):

--- a/spiketools/measures/trials.py
+++ b/spiketools/measures/trials.py
@@ -83,8 +83,8 @@ def compute_pre_post_rates(trial_spikes, pre_window, post_window):
     (array([6., 2., 0.]), array([ 2.5,  2.5, 10. ]))
     """
 
-    frs_pre = np.array([compute_firing_rate(trial, *pre_window) for trial in trial_spikes])
-    frs_post = np.array([compute_firing_rate(trial, *post_window) for trial in trial_spikes])
+    frs_pre = np.array([compute_firing_rate(trial, pre_window) for trial in trial_spikes])
+    frs_post = np.array([compute_firing_rate(trial, post_window) for trial in trial_spikes])
 
     return frs_pre, frs_post
 

--- a/spiketools/measures/trials.py
+++ b/spiketools/measures/trials.py
@@ -38,7 +38,7 @@ def compute_trial_frs(trial_spikes, bins, time_range=None, smooth=None):
     Compute the continuous firing rates across time bins for 3 trials:
 
     >>> trial_spikes = [np.array([0.005, 0.150, 0.250]), \
-                        np.array([0.126, 0.275, 0.300, 0.350, 0.500]), \
+                        np.array([0.126, 0.275, 0.300, 0.350, 0.600]), \
                         np.array([0.250, 0.350, 0.700, 0.900])]
     >>> bins = 0.5
     >>> time_range = [0.0, 1.0]
@@ -76,7 +76,7 @@ def compute_pre_post_rates(trial_spikes, pre_window, post_window):
     Compute the pre & post firing rates for specified time windows across 3 trials:
 
     >>> trial_spikes = [np.array([-0.150, -0.005, -0.002, 0.250, 0.450, 0.625]), \
-                        np.array([-0.250, 0.275, 0.290, 0.3, 0.350, 0.5]), \
+                        np.array([-0.250, 0.275, 0.290, 0.3, 0.350, 0.6]), \
                         np.array([0.550, 0.650, 0.70, 0.9, 0.950])]
     >>> pre_window, post_window = [-0.5, 0.0], [0.5, 0.9]
     >>> compute_pre_post_rates(trial_spikes, pre_window, post_window)

--- a/spiketools/spatial/place.py
+++ b/spiketools/spatial/place.py
@@ -121,11 +121,11 @@ def compute_trial_place_bins(spikes, position, timestamps, bins, start_times, st
     --------
     Compute spike activity in 1d spatial bins across 2 trials:
 
-    >>> spikes = np.array([0.2, 0.25, 0.3, 0.38, 0.41, 0.5, 0.59, 0.77, 0.95])
-    >>> position = np.array([1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
-    >>> timestamps = np.array([0.1, 0.2, 0.25, 0.4, 0.45, 0.46, 0.6, 0.7, 1.0])
+    >>> spikes = np.array([0.15, 0.22, 0.28, 0.38, 0.41, 0.50, 0.59, 0.77, 0.95])
+    >>> position = np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+    >>> timestamps = np.array([0.10, 0.20, 0.25, 0.35, 0.45, 0.46, 0.6, 0.65, 0.7, 0.95])
     >>> bins = 2
-    >>> start_times, stop_times = np.array([0, 0.4]), np.array([0.3, 1])
+    >>> start_times, stop_times = np.array([0, 0.6]), np.array([0.4, 1])
     >>> compute_trial_place_bins(spikes, position, timestamps, bins, start_times, stop_times)
     array([[10. , 40. ],
            [10. ,  7.5]])

--- a/spiketools/spatial/place.py
+++ b/spiketools/spatial/place.py
@@ -121,14 +121,14 @@ def compute_trial_place_bins(spikes, position, timestamps, bins, start_times, st
     --------
     Compute spike activity in 1d spatial bins across 2 trials:
 
-    >>> spikes = np.array([0.15, 0.22, 0.28, 0.38, 0.41, 0.50, 0.59, 0.77, 0.95])
-    >>> position = np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
-    >>> timestamps = np.array([0.10, 0.20, 0.25, 0.35, 0.45, 0.46, 0.6, 0.65, 0.7, 0.95])
+    >>> spikes = np.array([0.15, 0.22, 0.28, 0.41, 0.50, 0.65, 0.77, 0.81, 0.95])
+    >>> position = np.array([1.0, 3.5, 2.0, 1.5, 3.0, 3.5, 4.0, 5.0, 3.5, 2.5])
+    >>> timestamps = np.array([0.10, 0.20, 0.25, 0.35, 0.45, 0.55, 0.6, 0.7, 0.80, 0.95])
     >>> bins = 2
-    >>> start_times, stop_times = np.array([0, 0.6]), np.array([0.4, 1])
+    >>> start_times, stop_times = np.array([0, 0.6]), np.array([0.4, 1.0])
     >>> compute_trial_place_bins(spikes, position, timestamps, bins, start_times, stop_times)
-    array([[10. , 40. ],
-           [10. ,  7.5]])
+    array([[10., 20.],
+           [20.,  5.]])
     """
 
     t_occ = None

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -142,15 +142,15 @@ def test_threshold_spikes_by_values():
 
 def test_drop_range():
 
+    # test a single drop range
     spikes = np.array([0.5, 1.5, 1.9, 4.1, 5.4, 5.9])
     time_range = [2, 4]
-
     out = drop_range(spikes, time_range)
     assert isinstance(out, np.ndarray)
     assert spikes.shape == out.shape
     assert np.allclose(out, np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9]))
 
-    # check that error is raised with no empty range
+    # check that error is raised with a range that is not empty
     with raises(AssertionError):
         out = drop_range(spikes, [1.5, 4])
 
@@ -161,6 +161,11 @@ def test_drop_range():
     assert isinstance(out, np.ndarray)
     assert spikes.shape == out.shape
     assert np.allclose(out, np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9, 4.2, 5.7]))
+
+    # check that it works if passed an empty time range
+    time_range = []
+    out = drop_range(spikes, time_range)
+    assert np.array_equal(out, spikes)
 
 def test_reinstate_range_1d():
 

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -13,11 +13,17 @@ from spiketools.utils.extract import _reinstate_range_1d
 def test_create_mask():
 
     data = np.array([0.5, 1., 1.5, 2., 2.5])
-    min_value = 1
-    max_value = 2
+    min_value = 0.75
+    max_value = 2.25
     mask = create_mask(data, min_value, max_value)
     assert isinstance(mask, np.ndarray)
     assert np.array_equal(mask, np.array([False, True, True, True, False]))
+
+    # Test case on boundary
+    min_value2 = 1.
+    max_value2 = 2.
+    mask2 = create_mask(data, min_value2, max_value2)
+    assert np.array_equal(mask2, np.array([False, True, True, False, False]))
 
 def test_get_range():
 
@@ -26,21 +32,25 @@ def test_get_range():
     out1 = get_range(data, min_value=1.)
     assert np.array_equal(out1, np.array([1., 1.5, 2., 2.5]))
 
-    out2 = get_range(data, max_value=2.)
+    out2 = get_range(data, max_value=2.25)
     assert np.array_equal(out2, np.array([0.5, 1., 1.5, 2.]))
 
-    out3 = get_range(data, min_value=1., max_value=2.)
+    out3 = get_range(data, min_value=1., max_value=2.25)
     assert np.array_equal(out3, np.array([1., 1.5, 2.]))
 
-    out4 = get_range(data, min_value=1., max_value=2., reset=1.)
+    out4 = get_range(data, min_value=1., max_value=2.25, reset=1.)
     assert np.array_equal(out4, np.array([0., 0.5, 1.0]))
+
+    # Check range on boundary
+    out5 = get_range(data, min_value=1., max_value=2.)
+    assert np.array_equal(out5, np.array([1., 1.5]))
 
 def test_get_value_range():
 
     times = np.array([1., 2., 3., 4., 5.])
     data = np.array([0.5, 1., 1.5, 2., 2.5])
 
-    out_times, out_data = get_value_range(times, data, min_value=1., max_value=2.)
+    out_times, out_data = get_value_range(times, data, min_value=1., max_value=2.25)
     assert np.array_equal(out_times, np.array([2., 3., 4.]))
     assert np.array_equal(out_data, np.array([1., 1.5, 2.]))
 
@@ -177,6 +187,11 @@ def test_reinstate_range_1d():
     assert spikes.shape == out.shape
     assert get_range(out, *time_range).size == 0
     assert np.allclose(out, np.array([0.5, 1.5, 1.9, 4.1, 5.4, 5.9]))
+
+    # Test special case where a spike is the same value as time range start
+    time_range2 = [2.1, 3.4]
+    out2 = _reinstate_range_1d(spikes, time_range2)
+    assert spikes.shape == out2.shape
 
 def test_reinstate_range():
 

--- a/spiketools/tests/utils/test_timestamps.py
+++ b/spiketools/tests/utils/test_timestamps.py
@@ -75,6 +75,16 @@ def test_convert_time_to_nsamples():
     assert isinstance(out, int)
     assert out == 12
 
+def test_sum_time_ranges():
+
+    range1 = [0, 15.5]
+    out1 = sum_time_ranges(range1)
+    assert out1 == 15.5
+
+    ranges = [[0, 5.5], [10, 14.5]]
+    out2 = sum_time_ranges(ranges)
+    assert out2 == 10.0
+
 def test_split_time_value():
 
     value = 3600 + 1800 + 30

--- a/spiketools/tests/utils/test_timestamps.py
+++ b/spiketools/tests/utils/test_timestamps.py
@@ -77,6 +77,10 @@ def test_convert_time_to_nsamples():
 
 def test_sum_time_ranges():
 
+    range0 = []
+    out0 = sum_time_ranges(range0)
+    assert out0 == 0
+
     range1 = [0, 15.5]
     out1 = sum_time_ranges(range1)
     assert out1 == 15.5

--- a/spiketools/utils/epoch.py
+++ b/spiketools/utils/epoch.py
@@ -33,11 +33,11 @@ def epoch_spikes_by_event(spikes, events, window):
     --------
     Epoch spike times based on an event window:
 
-    >>> spikes = np.array([0.3, 0.4, 0.5, 0.6, 0.7, 1, 1.3])
+    >>> spikes = np.array([0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.3])
     >>> events = np.array([0.2, 0.8, 1.2])
-    >>> window = [0.0, 0.2]
+    >>> window = [0.0, 0.25]
     >>> epoch_spikes_by_event(spikes, events, window)
-    [array([0.1, 0.2]), array([0.2]), array([0.1])]
+    [array([0.1, 0.2]), array([0.1]), array([0.1])]
     """
 
     trials = [None] * len(events)
@@ -70,11 +70,11 @@ def epoch_spikes_by_range(spikes, start_times, stop_times, reset=False):
     --------
     Epoch an array of spiking data into trials, resetting each trial to start at time 0:
 
-    >>> spikes = np.array([0.1, 0.3, 0.4, 0.5, 0.6, 0.7, 1, 1.4])
+    >>> spikes = np.array([0.1, 0.2, 0.3, 0.5, 0.6, 0.7, 1, 1.4])
     >>> start_times = [0.0, 0.45, 0.9]
     >>> stop_times = [0.4, 0.85, 1.35]
     >>> epoch_spikes_by_range(spikes, start_times, stop_times, reset=True)
-    [array([0.1, 0.3, 0.4]), array([0.05, 0.15, 0.25]), array([0.1])]
+    [array([0.1, 0.2, 0.3]), array([0.05, 0.15, 0.25]), array([0.1])]
     """
 
     check_param_lengths([start_times, stop_times], ['start_times', 'stop_times'])
@@ -186,9 +186,9 @@ def epoch_data_by_event(timestamps, values, events, window):
     Epoch data into trials based on event windows:
 
     >>> timestamps = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
-    >>> values = np.array([1, 1.5, 2, 2.5, 3])
+    >>> values = np.array([1.0, 1.5, 2.0, 2.5, 3.0])
     >>> events = np.array([0.3, 0.6])
-    >>> window = [0.0, 0.2]
+    >>> window = [0.0, 0.25]
     >>> epoch_data_by_event(timestamps, values, events, window)
     ([array([0. , 0.2]), array([0.1])], [array([1.5, 2. ]), array([2.5])])
     """
@@ -234,7 +234,7 @@ def epoch_data_by_range(timestamps, values, start_times, stop_times, reset=False
     >>> timestamps = np.array([0.1, 0.3, 0.4, 0.5])
     >>> values = np.array([1, 2, 3, 4])
     >>> start_times = [0.2, 0.5]
-    >>> stop_times = [0.4, 0.7]
+    >>> stop_times = [0.45, 0.75]
     >>> epoch_data_by_range(timestamps, values, start_times, stop_times, reset=True)
     ([array([0.1, 0.2]), array([0.])], [array([2, 3]), array([4])])
     """

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -71,13 +71,13 @@ def get_range(data, min_value=None, max_value=None, reset=None):
     Get all values less than a specific value:
 
     >>> data = np.array([5, 10, 15, 20, 25, 30])
-    >>> get_range(data, min_value=None, max_value=25)
-    array([ 5, 10, 15, 20, 25])
+    >>> get_range(data, min_value=None, max_value=22.5)
+    array([ 5, 10, 15, 20])
 
     Get a specified range from a data array:
 
     >>> data = np.array([5, 10, 15, 20, 25, 30])
-    >>> get_range(data, min_value=10, max_value=20)
+    >>> get_range(data, min_value=10, max_value=22.5)
     array([10, 15, 20])
     """
 
@@ -193,7 +193,7 @@ def get_inds_by_times(timestamps, timepoints, threshold=None, drop_null=True):
     --------
     Get the corresponding indices for specified timepoints:
 
-    >>> timestamps = np.array([0.5, 1, 1.5, 2, 2.5, 3 ])
+    >>> timestamps = np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
     >>> timepoints = np.array([1, 2, 3])
     >>> get_inds_by_times(timestamps, timepoints)
     array([1, 3, 5])

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -16,8 +16,7 @@ def create_mask(data, min_value=None, max_value=None):
         Array of data.
     min_value, max_value : float, optional
         Minimum and/or maximum value to extract from the input array.
-    reset : float, optional
-        If provided, resets the values in the data array by the given reset value.
+        The minimum value is inclusive, but the maximum value is exclusive.
 
     Returns
     -------
@@ -29,14 +28,17 @@ def create_mask(data, min_value=None, max_value=None):
     Create a mask to select data within a given value range:
 
     >>> data = np.array([1, 2, 3, 4, 5, 6, 7, 8])
-    >>> create_mask(data, min_value=3, max_value=6)
+    >>> create_mask(data, min_value=2.5, max_value=6.5)
     array([False, False,  True,  True,  True,  True, False, False])
     """
 
     min_value = -np.inf if min_value is None else min_value
     max_value = np.inf if max_value is None else max_value
 
-    mask = np.logical_and(data >= min_value, data <= max_value)
+    # Make the mask inclusive for min / exclusive for max value
+    #   If inclusive for both, there can be issues double-selecting spikes
+    #   For example, if a spike ==  time_range, and select contiguous segments
+    mask = np.logical_and(data >= min_value, data < max_value)
 
     return mask
 
@@ -100,6 +102,7 @@ def get_value_range(timestamps, data, min_value=None, max_value=None, reset=None
         Data values, corresponding to the timestamps.
     min_value, max_value : float, optional
         Minimum and/or maximum value to extract from the input array.
+        The minimum value is inclusive, but the maximum value is exclusive.
     reset : float, optional
         If provided, resets the time values by the given reset value.
 
@@ -116,7 +119,7 @@ def get_value_range(timestamps, data, min_value=None, max_value=None, reset=None
 
     >>> data = np.array([1, 2, 3, 4, 5, 6, 7, 8])
     >>> timestamps = np.array([0.2, 0.3, 0.4, 0.5, 0.7, 0.9, 1.2, 1.5])
-    >>> get_value_range(timestamps, data, min_value=3, max_value=6)
+    >>> get_value_range(timestamps, data, min_value=2.5, max_value=6.5)
     (array([0.4, 0.5, 0.7, 0.9]), array([3, 4, 5, 6]))
     """
 

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -434,24 +434,27 @@ def drop_range(spikes, time_range, check_empty=True):
     array([0.24, 0.73, 1.22, 1.65, 2.15, 2.95, 3.52, 3.84])
     """
 
-    # Operate on a copy of the input, to not overwrite original array
-    spikes = spikes.copy()
+    # Check for time range is not empty (if is empty list, do nothing)
+    if time_range:
 
-    total_len = 0
-    for trange in np.array(time_range, ndmin=2):
+        # Operate on a copy of the input, to not overwrite original array
+        spikes = spikes.copy()
 
-        if total_len > 0:
-            trange = [trange[0] - total_len, trange[1] - total_len]
+        total_len = 0
+        for trange in np.array(time_range, ndmin=2):
 
-        if check_empty:
-            assert get_range(spikes, *trange).size == 0, \
-                "Extracted range {} is not empty.".format(trange)
+            if total_len > 0:
+                trange = [trange[0] - total_len, trange[1] - total_len]
 
-        tlen = trange[1] - trange[0]
-        spikes = np.hstack([get_range(spikes, max_value=trange[0]),
-                            get_range(spikes, min_value=trange[1], reset=tlen)])
+            if check_empty:
+                assert get_range(spikes, *trange).size == 0, \
+                    "Extracted range {} is not empty.".format(trange)
 
-        total_len += trange[1] - trange[0]
+            tlen = trange[1] - trange[0]
+            spikes = np.hstack([get_range(spikes, max_value=trange[0]),
+                                get_range(spikes, min_value=trange[1], reset=tlen)])
+
+            total_len += trange[1] - trange[0]
 
     return spikes
 

--- a/spiketools/utils/timestamps.py
+++ b/spiketools/utils/timestamps.py
@@ -224,7 +224,7 @@ def sum_time_ranges(ranges):
     10.0
     """
 
-    if isinstance(ranges[0], (int, float)):
+    if ranges and isinstance(ranges[0], (int, float)):
         ranges = [ranges]
 
     total = 0

--- a/spiketools/utils/timestamps.py
+++ b/spiketools/utils/timestamps.py
@@ -196,6 +196,44 @@ def convert_time_to_nsamples(time, fs):
     return n_samples
 
 
+def sum_time_ranges(ranges):
+    """Sum the total amount of time defined by time range(s).
+
+    Parameters
+    ----------
+    ranges : list of float or list of list of float
+        Time range(s) to sum the total defined time for.
+
+    Returns
+    -------
+    total : float
+        The total amount of time defined by the given time range(s).
+
+    Examples
+    --------
+    Sum the amount of time in a single time range:
+
+    >>> time_range = [2.5, 10]
+    >>> sum_total_range(time_range)
+    7.5
+
+    Sum the amount of time across a collection of time ranges:
+
+    >>> time_ranges = [[2.5, 10], [14, 15], [18.5, 20]]
+    >>> sum_total_range(time_ranges)
+    10.0
+    """
+
+    if isinstance(ranges[0], (int, float)):
+        ranges = [ranges]
+
+    total = 0
+    for crange in ranges:
+        total += crange[1] - crange[0]
+
+    return total
+
+
 def split_time_value(sec):
     """Split a time value from seconds to hours / minutes / seconds.
 

--- a/spiketools/utils/timestamps.py
+++ b/spiketools/utils/timestamps.py
@@ -214,13 +214,13 @@ def sum_time_ranges(ranges):
     Sum the amount of time in a single time range:
 
     >>> time_range = [2.5, 10]
-    >>> sum_total_range(time_range)
+    >>> sum_time_ranges(time_range)
     7.5
 
     Sum the amount of time across a collection of time ranges:
 
     >>> time_ranges = [[2.5, 10], [14, 15], [18.5, 20]]
-    >>> sum_total_range(time_ranges)
+    >>> sum_time_ranges(time_ranges)
     10.0
     """
 


### PR DESCRIPTION
This is a collection of updates, including:
- adding the `sum_time_ranges` helper function
- updates some management of selecting time_ranges to compute measures across
- some updates to doctests (trying to simplify)
- update to inclusiveness of time range selection**

**this is the most important update. Previously, we did all time selection with inclusive starts and ends, which seems nice (selecting [2, 4] from [1.2, 2.0, 3.1, 4.0] would return [2.0, 4.0]) - but this can lead to some problems, most notably, if we do something like stepwise segment extraction, we can select the same value twice (eg., the value 4.0 would be selected for both time ranges [2, 4] and for [4, 6]). To avoid this problem, this update makes all time range selections inclusive start, exclusive end (so - values >= start & < end). This is broadly consistent with what numpy does, so I think it makes sense. 