### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,7 @@ Documentation for ``spiketools`` is available
 
 The documentation includes:
 
-- `Tutorials <https://spiketools.github.io/spiketools/auto_tutorials/index.html>`_: which describe and work through each sub-module
-- `Examples <https://spiketools.github.io/spiketools/auto_examples/index.html>`_: demonstrating example applications and workflows
+- `Tutorials <https://spiketools.github.io/spiketools/auto_tutorials/index.html>`_: which describe and provide examples for each sub-module
 - `API List <https://spiketools.github.io/spiketools/api.html>`_: which lists and describes everything available in the module
 - `Glossary <https://spiketools.github.io/spiketools/glossary.html>`_: which defines key terms used in the module
 


### PR DESCRIPTION
Responds to #171 - dropping the "examples" link in the README that doesn't go anywhere. 

For context: the "Examples" link was originally copied over when creating the README / documentation side based on other tools I've worked on (eg [neurodsp](https://github.com/neurodsp-tools/neurodsp)), but so far we have not developed an examples page that is separate from the `Tutorials`. If/when we do add stand-alone examples, this page can be created and linked back in. 