### PR TITLE
[MNT] - Build & install related updates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE
+include LICENSE requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@
 #   coverage            For running test coverage
 #   pylint              For running linting on code
 #   setuptools          For creating distributions
-#   twine		For checking and publishing distributions
+#   build               For creating distributions
+#   twine               For checking and publishing distributions
 #
 # The following command line utilities are required:
 #   cloc                For counting code
@@ -98,13 +99,13 @@ summary:
 # Create a distribution build of the module
 dist:
 	@printf "\n\nCREATING DISTRIBUTION BUILD...\n"
-	@python setup.py sdist bdist_wheel
+	@python -m build
 	@printf "\n\nDISTRIBUTION BUILD CREATED\n\n\n"
 
 # Check a distribution build using twine
 check-dist:
 	@printf "\n\nCHECKING DISTRIBUTION BUILD:\n"
-	twine check dist/*
+	@twine check dist/*
 	@printf "\n"
 
 # Clear out distribution files

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version = __version__,
     description = 'Module for analyzing spiking data.',
     long_description = long_description,
+    long_description_content_type = 'text/x-rst',
     python_requires = '>=3.6',
     maintainer = 'Thomas Donoghue',
     maintainer_email = 'tdonoghue.research@gmail.com',

--- a/spiketools/tests/tsettings.py
+++ b/spiketools/tests/tsettings.py
@@ -1,7 +1,7 @@
 """Settings for tests."""
 
 import os
-import pkg_resources as pkg
+from pathlib import Path
 
 ###################################################################################################
 ###################################################################################################
@@ -11,5 +11,6 @@ FS = 100
 N_SAMPLES = 100
 
 # Set paths for test files
-BASE_TEST_FILE_PATH = pkg.resource_filename(__name__, 'test_files')
-TEST_PLOTS_PATH = os.path.join(BASE_TEST_FILE_PATH, 'plots')
+TESTS_PATH = Path(os.path.abspath(os.path.dirname(__file__)))
+BASE_TEST_FILE_PATH = TESTS_PATH / 'test_files'
+TEST_PLOTS_PATH = BASE_TEST_FILE_PATH / 'plots'


### PR DESCRIPTION
Updates:
- use `build` for distributions (see https://github.com/fooof-tools/fooof/pull/282/)
- drop use of `package_resources` (see https://github.com/fooof-tools/fooof/pull/281)