### PR TITLE
[BUG] - Fix listify for multi-d arrays

### DIFF
--- a/spiketools/tests/utils/test_base.py
+++ b/spiketools/tests/utils/test_base.py
@@ -1,5 +1,7 @@
 """Tests for spiketools.utils.base"""
 
+import numpy as np
+
 from spiketools.utils.base import *
 
 ###################################################################################################
@@ -109,6 +111,13 @@ def test_listify():
     assert listify(['test']) == ['test']
     assert listify(0.5) == [0.5]
     assert listify([0.5]) == [0.5]
+
+    # Test with array inputs
+    assert listify(np.array([1, 2, 3, 4])) == [1, 2, 3, 4]
+    out2d = listify(np.array([[1, 2], [3, 4]]))
+    assert isinstance(out2d, list)
+    assert len(out2d) == 1
+    assert np.array_equal(out2d[0], np.array([[1, 2], [3, 4]]))
 
     # Test with indexing
     listify([1, 2], index=True) == [[1, 2]]

--- a/spiketools/utils/base.py
+++ b/spiketools/utils/base.py
@@ -3,6 +3,8 @@
 from collections import Counter
 from collections.abc import Iterable
 
+import numpy as np
+
 ###################################################################################################
 ###################################################################################################
 
@@ -330,7 +332,7 @@ def check_keys(indict, lst):
     return output
 
 
-def listify(param, index=None):
+def listify(param, index=False):
     """Check and embed a parameter into a list, if is not already in a list.
 
     Parameters
@@ -347,11 +349,14 @@ def listify(param, index=None):
         Param embedded in a list.
     """
 
-    check = param[0] if index is not None else param
+    check = param[0] if index else param
 
     # Embed all non-iterable parameters into a list
     #   Note: deal with str as a special case of iterable that we want to embed
     if not isinstance(check, Iterable) or isinstance(check, str):
+        out = [param]
+    # Deal with special case of multi dimensional numpy arrays - want to embed without flattening
+    elif isinstance(check, np.ndarray) and np.ndim(check) > 1:
         out = [param]
     # If is iterable (eg tuple or numpy array), typecast to list
     else:


### PR DESCRIPTION
The `listify` function would end up flattening multi-dimensional arrays, which was unintended, and broke things like proper plotting in `plot_positions`. This fixes the `listify` function for explicitly handling multi-dimensional arrays, also fixing downstream effects. 