### PR TITLE
[MNT] - Update shuffle poisson approach

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -249,7 +249,6 @@ Methods and measures related to permutation statistics.
 .. autosummary::
    :toctree: generated/
 
-   permute_vector
    compute_surrogate_pvalue
    compute_surrogate_zscore
    compute_surrogate_stats
@@ -487,9 +486,11 @@ Utilities for working with arrays of data.
 .. autosummary::
    :toctree: generated/
 
+   make_row_orientation
    compute_range
    smooth_data
    drop_nans
+   permute_vector
    assign_data_to_bins
 
 Extract

--- a/spiketools/stats/permutations.py
+++ b/spiketools/stats/permutations.py
@@ -8,52 +8,6 @@ from spiketools.plts.stats import plot_surrogates
 ###################################################################################################
 ###################################################################################################
 
-def permute_vector(data, n_permutations=1000):
-    """Create permutations of a vector of data.
-
-    Parameters
-    ----------
-    data : 1d array
-        Vector to permute.
-    n_permutations : int, optional, default: 1000
-        Number of permutations to do.
-
-    Returns
-    -------
-    permutations : 2d array
-        Permutations of the input data.
-
-    Notes
-    -----
-    Code adapted from here: https://stackoverflow.com/questions/46859304/
-
-    This function doesn't have any randomness - for a given array it will
-    iterate through the same set of permutations, in sequence.
-
-    Examples
-    --------
-    Create permutations for a vector of data:
-
-    >>> data = np.array([0, 5, 10, 15, 20])
-    >>> permute_vector(data, n_permutations=4)
-    array([[ 0,  5, 10, 15, 20],
-           [ 5, 10, 15, 20,  0],
-           [10, 15, 20,  0,  5],
-           [15, 20,  0,  5, 10]])
-    """
-
-    assert data.ndim == 1, 'The permute_vector function only works on 1d arrays.'
-
-    data_ext = np.concatenate((data, data[:-1]))
-    strides = data.strides[0]
-    permutations = np.lib.stride_tricks.as_strided(data_ext,
-                                                   shape=(n_permutations, len(data)),
-                                                   strides=(strides, strides),
-                                                   writeable=False).copy()
-
-    return permutations
-
-
 def compute_surrogate_pvalue(value, surrogates):
     """Compute the empirical p-value from a distribution of surrogates.
 

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -8,7 +8,6 @@ from spiketools.measures.spikes import compute_isis, compute_firing_rate
 from spiketools.measures.conversions import (convert_times_to_train, convert_isis_to_times,
                                              convert_train_to_times)
 from spiketools.stats.generators import poisson_generator
-from spiketools.stats.permutations import permute_vector
 from spiketools.utils.checks import check_param_options
 from spiketools.utils.extract import drop_range, reinstate_range
 

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -24,7 +24,7 @@ def shuffle_spikes(spikes, approach, n_shuffles=1000, **kwargs):
         Spike times, in seconds.
     approach : {'isi', 'circular', 'bincirc'}
         Which approach to take for shuffling spike times.
-        See sub-functions for details.
+        See shuffle sub-functions for details.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
     kwargs
@@ -268,7 +268,7 @@ def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000):
 
 @drop_shuffle_range
 def shuffle_poisson(spikes, n_shuffles=1000):
-    """Shuffle spikes based on a Poisson distribution.
+    """Shuffle spikes based on generating new spike trains from a Poisson distribution.
 
     Parameters
     ----------
@@ -284,7 +284,16 @@ def shuffle_poisson(spikes, n_shuffles=1000):
 
     Notes
     -----
-    This is an experimental implementation, and still has some issues matching spike counts.
+    This approach creates "shuffles" by simulating new spike trains from a Poisson distribution.
+
+    Note that this approach is therefore not strictly a "shuffle" in the sense that the outputs
+    are not literally 'shuffled' versions of the input, and are instead new / simulated set of spikes
+    sampled based on the statistics of the input.
+
+    In addition, since this approach simulates new spike trains based on an average rate, different
+    iterations of the shuffles are not guaranteed to have the same number of spikes (and are not
+    guaranteed to have the same number of spikes as the input). This is why the outputs are returned
+    are a list of shuffles.
 
     Examples
     --------

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -22,8 +22,9 @@ def shuffle_spikes(spikes, approach, n_shuffles=1000, **kwargs):
     ----------
     spikes : 1d array
         Spike times, in seconds.
-    approach : {'isi', 'bincirc', 'poisson', 'circular'}
+    approach : {'isi', 'circular', 'bincirc'}
         Which approach to take for shuffling spike times.
+        See sub-functions for details.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
     kwargs
@@ -54,19 +55,16 @@ def shuffle_spikes(spikes, approach, n_shuffles=1000, **kwargs):
     # Use lowered string, for backwards compatibility for options were upper case
     approach = approach.lower()
 
-    check_param_options(approach, 'approach', ['isi', 'bincirc', 'poisson', 'circular'])
+    check_param_options(approach, 'approach', ['isi', 'circular', 'bincirc'])
 
     if approach == 'isi':
         shuffled_spikes = shuffle_isis(spikes, n_shuffles=n_shuffles)
 
-    elif approach == 'bincirc':
-        shuffled_spikes = shuffle_bins(spikes, n_shuffles=n_shuffles, **kwargs)
-
-    elif approach == 'poisson':
-        shuffled_spikes = shuffle_poisson(spikes, n_shuffles=n_shuffles)
-
     elif approach == 'circular':
         shuffled_spikes = shuffle_circular(spikes, n_shuffles=n_shuffles, **kwargs)
+
+    elif approach == 'bincirc':
+        shuffled_spikes = shuffle_bins(spikes, n_shuffles=n_shuffles, **kwargs)
 
     return shuffled_spikes
 
@@ -138,6 +136,52 @@ def shuffle_isis(spikes, n_shuffles=1000):
     shuffled_spikes = np.zeros([n_shuffles, spikes.shape[-1]])
     for ind in range(n_shuffles):
         shuffled_spikes[ind, :] = convert_isis_to_times(np.random.permutation(isis))
+
+    return shuffled_spikes
+
+
+@drop_shuffle_range
+def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000):
+    """Shuffle spikes based on circularly shifting the spike train.
+
+    Parameters
+    ----------
+    spikes : 1d array
+        Spike times, in seconds.
+    shuffle_min : int
+        The minimum amount to rotate data, in terms of units of the spike train.
+    n_shuffles : int, optional, default: 1000
+        The number of shuffles to create.
+
+    Returns
+    -------
+    shuffled_spikes : 2d array
+        Shuffled spike times.
+
+    Notes
+    -----
+    The input shuffle_min should always be less than the maximum time in which a spike occurred.
+
+    Examples
+    --------
+    Shuffle spike times using the circular method:
+
+    >>> from spiketools.sim.times import sim_spiketimes
+    >>> spikes = sim_spiketimes(5, 30, 'poisson')
+    >>> shuffled_spikes = shuffle_circular(spikes, shuffle_min=10000, n_shuffles=5)
+    """
+
+    spike_train = convert_times_to_train(spikes)
+
+    shuffles = np.random.randint(low=shuffle_min,
+                                 high=len(spike_train)-shuffle_min,
+                                 size=n_shuffles)
+
+    shuffled_spikes = np.zeros([n_shuffles, len(spikes)])
+
+    for ind, shuffle in enumerate(shuffles):
+        temp_train = np.roll(spike_train, shuffle)
+        shuffled_spikes[ind, :] = convert_train_to_times(temp_train)
 
     return shuffled_spikes
 
@@ -235,7 +279,7 @@ def shuffle_poisson(spikes, n_shuffles=1000):
 
     Returns
     -------
-    shuffled_spikes : 2d array
+    shuffled_spikes : list of 1d array
         Shuffled spike times.
 
     Notes
@@ -254,56 +298,8 @@ def shuffle_poisson(spikes, n_shuffles=1000):
     rate = compute_firing_rate(spikes)
     length = (spikes[-1] - spikes[0])
 
-    poisson_spikes = list(poisson_generator(rate, length)) + spikes[0]
-
-    isis = permute_vector(compute_isis(poisson_spikes), n_permutations=n_shuffles)
-
-    shuffled_spikes = np.cumsum(isis, axis=1) + spikes[0]
-
-    return shuffled_spikes
-
-
-@drop_shuffle_range
-def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000):
-    """Shuffle spikes based on circularly shifting the spike train.
-
-    Parameters
-    ----------
-    spikes : 1d array
-        Spike times, in seconds.
-    shuffle_min : int
-        The minimum amount to rotate data, in terms of units of the spike train.
-    n_shuffles : int, optional, default: 1000
-        The number of shuffles to create.
-
-    Returns
-    -------
-    shuffled_spikes : 2d array
-        Shuffled spike times.
-
-    Notes
-    -----
-    The input shuffle_min should always be less than the maximum time in which a spike occurred.
-
-    Examples
-    --------
-    Shuffle spike times using the circular method:
-
-    >>> from spiketools.sim.times import sim_spiketimes
-    >>> spikes = sim_spiketimes(5, 30, 'poisson')
-    >>> shuffled_spikes = shuffle_circular(spikes, shuffle_min=10000, n_shuffles=5)
-    """
-
-    spike_train = convert_times_to_train(spikes)
-
-    shuffles = np.random.randint(low=shuffle_min,
-                                 high=len(spike_train)-shuffle_min,
-                                 size=n_shuffles)
-
-    shuffled_spikes = np.zeros([n_shuffles, len(spikes)])
-
-    for ind, shuffle in enumerate(shuffles):
-        temp_train = np.roll(spike_train, shuffle)
-        shuffled_spikes[ind, :] = convert_train_to_times(temp_train)
+    shuffled_spikes = [None] * n_shuffles
+    for ind in range(n_shuffles):
+        shuffled_spikes[ind] = list(poisson_generator(rate, length)) + spikes[0]
 
     return shuffled_spikes

--- a/spiketools/tests/stats/test_permutations.py
+++ b/spiketools/tests/stats/test_permutations.py
@@ -5,15 +5,6 @@ from spiketools.stats.permutations import *
 ###################################################################################################
 ###################################################################################################
 
-def test_permute_vector():
-
-    n_permutations = 5
-    data = np.array([1, 2, 3, 4, 5])
-
-    out = permute_vector(data, n_permutations=n_permutations)
-    assert isinstance(out, np.ndarray)
-    assert out.shape == (n_permutations, len(data))
-
 def test_compute_empirical_pvalue(tdata):
 
     p_value = compute_surrogate_pvalue(1.5, tdata)

--- a/spiketools/tests/stats/test_shuffle.py
+++ b/spiketools/tests/stats/test_shuffle.py
@@ -12,8 +12,8 @@ from spiketools.stats.shuffle import *
 
 def test_shuffle_spikes(tspikes):
 
-    approaches = ['ISI', 'BINCIRC', 'POISSON', 'CIRCULAR']
-    kwargs = [{}, {}, {}, {'shuffle_min' : 10}]
+    approaches = ['ISI', 'CIRCULAR', 'BINCIRC']
+    kwargs = [{}, {'shuffle_min' : 10}, {}]
 
     for approach, kwarg in zip(approaches, kwargs):
         shuffled = shuffle_spikes(tspikes, approach=approach, n_shuffles=1, **kwarg)
@@ -59,6 +59,25 @@ def test_shuffle_isis(tspikes):
     out_many = shuffle_isis(tspikes, n_shuffles=n_shuffles)
     assert out_many.shape == (n_shuffles, len(tspikes))
 
+def test_shuffle_circular(tspikes):
+
+    shuffled = shuffle_circular(tspikes, 10, n_shuffles=1)
+    assert isinstance(shuffled, np.ndarray)
+    assert tspikes.shape[-1] == shuffled.shape[-1]
+    assert not np.array_equal(tspikes, shuffled)
+
+    # Test that get a different answer with different random states
+    set_random_seed(12)
+    out1 = shuffle_circular(tspikes, 10, n_shuffles=1)
+    set_random_seed(21)
+    out2 = shuffle_circular(tspikes, 10, n_shuffles=1)
+    assert not np.array_equal(out1, out2)
+
+    # Test with more shuffles
+    n_shuffles = 5
+    out_many = shuffle_circular(tspikes, 10, n_shuffles=n_shuffles)
+    assert out_many.shape == (n_shuffles, len(tspikes))
+
 def test_shuffle_bins(tspikes):
 
     shuffled = shuffle_bins(tspikes, n_shuffles=1)
@@ -81,9 +100,7 @@ def test_shuffle_bins(tspikes):
 def test_shuffle_poisson(tspikes):
 
     shuffled = shuffle_poisson(tspikes)
-    assert isinstance(shuffled, np.ndarray)
-    # Shape test turned off, as number of spikes is not currently guaranteed
-    #assert tspikes.shape[-1] == shuffled.shape[-1]
+    assert isinstance(shuffled, list)
     assert not np.array_equal(tspikes, shuffled)
 
     # Test that get a different answer with different random states
@@ -92,27 +109,7 @@ def test_shuffle_poisson(tspikes):
     assert not np.array_equal(out1, out2)
 
     # Test with more shuffles
-    #   Note: here we check the correct number of shuffles,
-    #     but not the exact number of spikes, which is not guaranteed
+    #   Note: checks the # of shuffles, but not the exact # of spikes, which is not guaranteed
     n_shuffles = 5
     out_many = shuffle_poisson(tspikes, n_shuffles=n_shuffles)
-    assert out_many.shape[0] == n_shuffles
-
-def test_shuffle_circular(tspikes):
-
-    shuffled = shuffle_circular(tspikes, 10, n_shuffles=1)
-    assert isinstance(shuffled, np.ndarray)
-    assert tspikes.shape[-1] == shuffled.shape[-1]
-    assert not np.array_equal(tspikes, shuffled)
-
-    # Test that get a different answer with different random states
-    set_random_seed(12)
-    out1 = shuffle_circular(tspikes, 10, n_shuffles=1)
-    set_random_seed(21)
-    out2 = shuffle_circular(tspikes, 10, n_shuffles=1)
-    assert not np.array_equal(out1, out2)
-
-    # Test with more shuffles
-    n_shuffles = 5
-    out_many = shuffle_circular(tspikes, 10, n_shuffles=n_shuffles)
-    assert out_many.shape == (n_shuffles, len(tspikes))
+    assert len(out_many) == n_shuffles

--- a/spiketools/tests/utils/test_data.py
+++ b/spiketools/tests/utils/test_data.py
@@ -56,6 +56,15 @@ def test_drop_nans():
     assert isinstance(out, np.ndarray)
     assert np.array_equal(out, np.array([[0.5, 1.0, 1.5, 2.0, 2.5], [0.5, 1.0, 1.5, 2.0, 2.5]]))
 
+def test_permute_vector():
+
+    n_permutations = 5
+    data = np.array([1, 2, 3, 4, 5])
+
+    out = permute_vector(data, n_permutations=n_permutations)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (n_permutations, len(data))
+
 def test_assign_data_to_bins():
 
     data = np.array([1, 3, 5, 7])

--- a/spiketools/utils/data.py
+++ b/spiketools/utils/data.py
@@ -136,6 +136,52 @@ def drop_nans(data):
     return data
 
 
+def permute_vector(data, n_permutations=1000):
+    """Create permutations of a vector of data.
+
+    Parameters
+    ----------
+    data : 1d array
+        Vector to permute.
+    n_permutations : int, optional, default: 1000
+        Number of permutations to do.
+
+    Returns
+    -------
+    permutations : 2d array
+        Permutations of the input data.
+
+    Notes
+    -----
+    Code adapted from here: https://stackoverflow.com/questions/46859304/
+
+    This function doesn't have any randomness - for a given array it will
+    iterate through the same set of permutations, in sequence.
+
+    Examples
+    --------
+    Create permutations for a vector of data:
+
+    >>> data = np.array([0, 5, 10, 15, 20])
+    >>> permute_vector(data, n_permutations=4)
+    array([[ 0,  5, 10, 15, 20],
+           [ 5, 10, 15, 20,  0],
+           [10, 15, 20,  0,  5],
+           [15, 20,  0,  5, 10]])
+    """
+
+    assert data.ndim == 1, 'The permute_vector function only works on 1d arrays.'
+
+    data_ext = np.concatenate((data, data[:-1]))
+    strides = data.strides[0]
+    permutations = np.lib.stride_tricks.as_strided(data_ext,
+                                                   shape=(n_permutations, len(data)),
+                                                   strides=(strides, strides),
+                                                   writeable=False).copy()
+
+    return permutations
+
+
 def assign_data_to_bins(data, edges, check_range=True, include_edge=True):
     """Assign data values to data bins, based on given edges.
 

--- a/tutorials/plot_stats.py
+++ b/tutorials/plot_stats.py
@@ -31,8 +31,7 @@ This tutorial primarily covers the ``spiketools.stats`` module.
 import numpy as np
 
 # Import statistics-related functions
-from spiketools.stats.shuffle import (shuffle_spikes, shuffle_isis, shuffle_bins,
-                                      shuffle_poisson, shuffle_circular)
+from spiketools.stats.shuffle import shuffle_spikes, shuffle_isis, shuffle_circular, shuffle_bins
 from spiketools.stats.permutations import compute_surrogate_stats
 from spiketools.stats.anova import create_dataframe, create_dataframe_bins, fit_anova
 from spiketools.stats.trials import (compute_pre_post_ttest, compare_pre_post_activity,
@@ -74,18 +73,16 @@ spikes = sim_spiketimes(10, 100, 'poisson', refractory=0.001)
 # The approaches we will try are:
 #
 # - :func:`~.shuffle_isis`: shuffle spike times using permuted inter-spike intervals (isis)
-# - :func:`~.shuffle_bins`: shuffle spikes by circularly shuffling bins of varying length
-# - :func:`~.shuffle_poisson`: shuffle spikes based on a Poisson distribution
 # - :func:`~.shuffle_circular`: shuffle spikes by circularly shifting the spike train
+# - :func:`~.shuffle_bins`: shuffle spikes by circularly shuffling bins of varying length
 #
 
 ###################################################################################################
 
 # Shuffle spikes using the four described methods
 shuffled_isis = shuffle_isis(spikes, n_shuffles=10)
-shuffled_bins = shuffle_bins(spikes, bin_width_range=[0.5, 7], n_shuffles=10)
-shuffled_poisson = shuffle_poisson(spikes, n_shuffles=10)
 shuffled_circular = shuffle_circular(spikes, shuffle_min=200, n_shuffles=10)
+shuffled_bins = shuffle_bins(spikes, bin_width_range=[0.5, 7], n_shuffles=10)
 
 ###################################################################################################
 
@@ -95,23 +92,19 @@ plot_rasters(spikes, xlim=[0, 6], title='Non-shuffled', vline=None)
 ###################################################################################################
 
 # Plot different shuffles
-ax1, ax2, ax3, ax4 = make_axes(4, 2, sharey=True, hspace=0.3, figsize=(15, 7))
+ax1, ax2, ax3 = make_axes(3, 1, sharey=True, hspace=0.3, figsize=(14, 9))
 
 # Shuffle spikes based on inter-spike intervals
 plot_rasters(shuffled_isis, xlim=[0, 6], ax=ax1,
              title='Shuffle ISIS n_shuffles = 10')
 
-# Shuffle spikes Poisson
-plot_rasters(shuffled_poisson, xlim=[0, 6], ax=ax2,
-             title='Shuffle Poisson n_shuffles = 10')
+# Circular shuffle
+plot_rasters(shuffled_circular, xlim=[0, 6], ax=ax2,
+             title='Shuffle circular n_shuffles = 10')
 
 # Shuffled spikes using a binned circular shuffle
 plot_rasters(shuffled_bins, xlim=[0, 6], ax=ax3,
              title='Shuffle bins n_shuffles = 10')
-
-# Circular shuffle
-plot_rasters(shuffled_circular, xlim=[0, 6], ax=ax4,
-             title='Shuffle circular n_shuffles = 10')
 
 ###################################################################################################
 #


### PR DESCRIPTION
Updates to the shuffle Poisson approach:

Mainly, it responds to #163, making the Poisson shuffle approach regenerate a new set of Poisson generated spikes per 'shuffle'. This fixes the previous issue of simply permuting a single shuffle. However, since the Poisson generation is not guaranteed to return the same number of spikes, this means that this approach now returns a list of shuffles, each array within the list which can have somewhat different length. 

Because the shuffle poisson doesn't return a uniform array like the other function, I also removed it from being an option in the `shuffle_spikes` function. I think this is consistent with us not really recommending this approach (not to mention that it's not a "shuffling" function in the sense that spikes are not shuffled, but rather simulated.

Also, this moves the `permute_vector` function to utils, since it doesn't really do what we want it to, and is no longer used in our shuffle functions (but might as well keep it around). 