### PR TITLE
[MNT] - Update thresholds in occupancy calculations

### DIFF
--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -432,8 +432,8 @@ def compute_occupancy_df(bindf, bins, minimum=None, normalize=False, set_nan=Fal
 
 
 def compute_occupancy(position, timestamps, bins, area_range=None, speed=None,
-                      speed_threshold=None, time_threshold=None, check_range=True,
-                      minimum=None, normalize=False, set_nan=False):
+                      min_speed=None, max_speed=None, min_time=None, max_time=None,
+                      check_range=True, minimum=None, normalize=False, set_nan=False):
     """Compute occupancy across spatial bin positions.
 
     Parameters
@@ -450,12 +450,12 @@ def compute_occupancy(position, timestamps, bins, area_range=None, speed=None,
     speed : 1d array, optional
         Current speed for each position.
         Should be the same length as timestamps.
-    speed_threshold : float, optional
-        Speed threshold to apply.
-        If provided, any position values with an associated speed below this value are dropped.
-    time_threshold : float, optional
-        A maximum time threshold, per bin observation, to apply.
-        If provided, any bin values with an associated time length above this value are dropped.
+    min_speed, max_speed : float, optional
+        Minimum and/or maximum speed thresholds to apply.
+        Any entries with an associated speed below the minimum or above maximum are dropped.
+    min_time, max_time : float, optional
+        Minimum and/or maximum time thresholds, per bin observation, to apply.
+        Any entries with an associated time length below the minimum or above maximum are dropped.
     check_range : bool, optional, default: True
         Whether to check the given bin definition range against the position values.
     minimum : float, optional
@@ -498,7 +498,7 @@ def compute_occupancy(position, timestamps, bins, area_range=None, speed=None,
     """
 
     df = create_position_df(position, timestamps, bins, area_range,
-                            speed, speed_threshold, time_threshold,
+                            speed, min_speed, max_speed, min_time, max_time,
                             check_range=check_range)
     occupancy = compute_occupancy_df(df, bins, minimum, normalize, set_nan)
 
@@ -506,8 +506,8 @@ def compute_occupancy(position, timestamps, bins, area_range=None, speed=None,
 
 
 def compute_trial_occupancy(position, timestamps, bins, start_times, stop_times,
-                            area_range=None, speed=None, speed_threshold=None,
-                            time_threshold=None, orientation=None, **occupancy_kwargs):
+                            area_range=None, speed=None, min_speed=None, max_speed=None,
+                            min_time=None, max_time=None, orientation=None, **occupancy_kwargs):
     """Compute trial-level occupancy across spatial bin positions.
 
     Parameters
@@ -526,12 +526,12 @@ def compute_trial_occupancy(position, timestamps, bins, start_times, stop_times,
     speed : 1d array, optional
         Current speed for each position.
         Should be the same length as timestamps.
-    speed_threshold : float, optional
-        Speed threshold to apply.
-        If provided, any position values with an associated speed below this value are dropped.
-    time_threshold : float, optional
-        A maximum time threshold, per bin observation, to apply.
-        If provided, any bin values with an associated time length above this value are dropped.
+    min_speed, max_speed : float, optional
+        Minimum and/or maximum speed thresholds to apply.
+        Any entries with an associated speed below the minimum or above maximum are dropped.
+    min_time, max_time : float, optional
+        Minimum and/or maximum time thresholds, per bin observation, to apply.
+        Any entries with an associated time length below the minimum or above maximum are dropped.
     orientation : {'row', 'column'}, optional
         The orientation of the position data.
         If not provided, is inferred from the position data.
@@ -585,7 +585,8 @@ def compute_trial_occupancy(position, timestamps, bins, start_times, stop_times,
             _, t_speed = get_values_by_time_range(timestamps, speed, start, stop)
 
         trial_occupancy[ind, :] = compute_occupancy(\
-            t_pos, t_times, bins, area_range, t_speed, speed_threshold,
-            time_threshold, **occupancy_kwargs)
+            t_pos, t_times, bins, area_range, t_speed,
+            min_speed, max_speed, min_time, max_time,
+            **occupancy_kwargs)
 
     return trial_occupancy

--- a/spiketools/tests/spatial/test_occupancy.py
+++ b/spiketools/tests/spatial/test_occupancy.py
@@ -150,16 +150,21 @@ def test_create_position_df():
     assert len(df) == position.shape[-1]
     assert np.array_equal(df.xbin.values, np.array([0, 0, 1, 1]))
 
-    # check speed dropping - drop a time bin with zero speed
-    speed = np.array([1, 1, 0, 1])
-    df = create_position_df(position, timestamps, bins, speed=speed, speed_threshold=0.5)
+    # check speed dropping - drop entries based on min or max speed thresholds
+    speed = np.array([1, 1, 0, 2])
+    df = create_position_df(position, timestamps, bins, speed=speed, min_speed=0.5)
     assert np.all(df.index == [0, 1, 3]) # check correct index dropped
     assert np.array_equal(df.xbin.values, np.array([0, 0, 1])) # check expected bin output
+    df = create_position_df(position, timestamps, bins, speed=speed, max_speed=1.5)
+    assert np.all(df.index == [0, 1, 2]) # check correct index dropped
+    assert np.array_equal(df.xbin.values, np.array([0, 0, 1])) # check expected bin output
 
-    # check time threshold - drop a long time bin (should drop position at index 2)
-    timestamps = np.array([0, 1.5, 2.5, 10])
-    time_threshold = 2.0
-    df = create_position_df(position, timestamps, bins, time_threshold=time_threshold)
+    # check time threshold - drop entries based on min or miax time in bin
+    timestamps = np.array([0, 0.5, 1.5, 10])
+    df = create_position_df(position, timestamps, bins, min_time=1.0)
+    assert np.all(df.index == [1, 2]) # check correct index dropped
+    assert np.array_equal(df.xbin.values, np.array([0, 1])) # check expected bin output
+    df = create_position_df(position, timestamps, bins, max_time=2.0)
     assert np.all(df.index == [0, 1, 3]) # check correct index dropped
     assert np.array_equal(df.xbin.values, np.array([0, 0, 1])) # check expected bin output
 

--- a/spiketools/tests/spatial/test_occupancy.py
+++ b/spiketools/tests/spatial/test_occupancy.py
@@ -140,7 +140,7 @@ def test_normalize_bin_counts():
 
 def test_create_position_df():
 
-    timestamps = np.array([5, 5, 5, 5])
+    timestamps = np.array([0, 1, 2, 3])
 
     # 1d case
     bins = 2
@@ -150,11 +150,18 @@ def test_create_position_df():
     assert len(df) == position.shape[-1]
     assert np.array_equal(df.xbin.values, np.array([0, 0, 1, 1]))
 
-    # check speed dropping
+    # check speed dropping - drop a time bin with zero speed
     speed = np.array([1, 1, 0, 1])
     df = create_position_df(position, timestamps, bins, speed=speed, speed_threshold=0.5)
-    assert len(df) == sum(speed)
-    assert np.array_equal(df.xbin.values, np.array([0, 0, 1]))
+    assert np.all(df.index == [0, 1, 3]) # check correct index dropped
+    assert np.array_equal(df.xbin.values, np.array([0, 0, 1])) # check expected bin output
+
+    # check time threshold - drop a long time bin (should drop position at index 2)
+    timestamps = np.array([0, 1.5, 2.5, 10])
+    time_threshold = 2.0
+    df = create_position_df(position, timestamps, bins, time_threshold=time_threshold)
+    assert np.all(df.index == [0, 1, 3]) # check correct index dropped
+    assert np.array_equal(df.xbin.values, np.array([0, 0, 1])) # check expected bin output
 
     # 2d case
     bins = [2, 2]

--- a/tutorials/plot_spatial.py
+++ b/tutorials/plot_spatial.py
@@ -235,12 +235,12 @@ print('The time durations of position samples are: ', sample_times)
 
 ###################################################################################################
 
-# Define speed threshold, used to remove position values if the speed is less than the threshold
-speed_thresh = .5e-3
+# Define minimum speed threshold, used to remove entries if the speed is less than the threshold
+min_speed = .5e-3
 
 # Compute the 2D occupancy
 occupancy = compute_occupancy(position, timestamps, bins,
-                              speed=speeds, speed_threshold=speed_thresh)
+                              speed=speeds, min_speed=min_speed)
 
 # Plot the compute 2D occupancy
 plot_heatmap(occupancy, cbar=True,
@@ -275,7 +275,7 @@ plot_heatmap(bin_counts_pos, cbar=True,
 
 # Compute the 1D occupancy
 occupancy_1d = compute_occupancy(position[0], timestamps, bins[0],
-                                 speed=speeds, speed_threshold=speed_thresh)
+                                 speed=speeds, min_speed=min_speed)
 
 # Plot the 1D occupancy
 plot_heatmap(occupancy_1d, title='X-occupancy heatmap w/ speed threshold')


### PR DESCRIPTION
Responds to #179 

Previously, it was sort of confusing the `speed_threshold` was a MINIMUM value, but `time_threshold` was a MAXIMUM value, and also, this scheme only allowed for a subset of thresholding one might want to do (not allowing, for example, for dropping entries with too short a time duration. 

This PR therefor updates speed & time threshold to use explicit `min_x` and `max_x` threshold values for both, which I think is probably better. 

The only sorta annoying thing is that this is a breaking change (changes the argument names), so some older code will need to be updated. Any thoughts on this are welcome!