### PR TITLE
[MNT] - Update management of position orientation inference for ambiguous cases

### DIFF
--- a/spiketools/plts/spatial.py
+++ b/spiketools/plts/spatial.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 from spiketools.utils.base import (listify, combine_dicts, relabel_keys,
                                    drop_key_prefix, subset_dict)
 from spiketools.utils.checks import check_array_lst_orientation
-from spiketools.utils.data import make_row_orientation, smooth_data, compute_range
+from spiketools.utils.data import make_orientation, smooth_data, compute_range
 from spiketools.modutils.functions import get_function_parameters
 from spiketools.plts.annotate import add_dots, add_gridlines
 from spiketools.plts.settings import DEFAULT_COLORS
@@ -56,7 +56,7 @@ def plot_positions(position, spike_positions=None, landmarks=None, x_bins=None,
 
     orientation = check_array_lst_orientation(listify(position))
     for cur_position in listify(position):
-        ax.plot(*make_row_orientation(cur_position, orientation),
+        ax.plot(*make_orientation(cur_position, 'row', orientation),
                 color=plt_kwargs.pop('color', DEFAULT_COLORS[0]),
                 alpha=plt_kwargs.pop('alpha', 0.35),
                 **plt_kwargs)
@@ -64,20 +64,20 @@ def plot_positions(position, spike_positions=None, landmarks=None, x_bins=None,
     if spike_positions is not None:
         defaults = {'color' : 'red', 'alpha' : 0.4, 'ms' : 6}
         if isinstance(spike_positions, np.ndarray):
-            add_dots(make_row_orientation(spike_positions, orientation),
+            add_dots(make_orientation(spike_positions, 'row', orientation),
                      ax=ax, **defaults)
         elif isinstance(spike_positions, dict):
-            add_dots(make_row_orientation(spike_positions.pop('positions'), orientation),
+            add_dots(make_orientation(spike_positions.pop('positions'), 'row', orientation),
                      ax=ax, **{**defaults, **spike_positions})
 
     if landmarks is not None:
         defaults = {'alpha' : 0.85, 'ms' : 12}
         for landmark in [landmarks] if not isinstance(landmarks, list) else landmarks:
             if isinstance(landmark, np.ndarray):
-                add_dots(make_row_orientation(landmark, orientation),
+                add_dots(make_orientation(landmark, 'row', orientation),
                          ax=ax, **defaults)
             elif isinstance(landmark, dict):
-                add_dots(make_row_orientation(landmark.pop('positions'), orientation),
+                add_dots(make_orientation(landmark.pop('positions'), 'row', orientation),
                          ax=ax, **landmark)
 
     add_gridlines(x_bins, y_bins, ax)

--- a/spiketools/spatial/distance.py
+++ b/spiketools/spatial/distance.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from spiketools.utils.checks import check_array_orientation
+from spiketools.utils.data import make_orientation
 
 ###################################################################################################
 ###################################################################################################
@@ -69,7 +70,7 @@ def compute_distances(position):
     array([1.        , 1.        , 1.41421356])
     """
 
-    position = position.T if check_array_orientation(position) == 'row' else position
+    position = make_orientation(position, 'column')
 
     distances = np.zeros(len(position) - 1)
     for ix, (p1, p2) in enumerate(zip(position, position[1:])):
@@ -152,7 +153,7 @@ def compute_distances_to_location(position, location):
     array([1.41421356, 1.        , 0.        , 1.41421356])
     """
 
-    position = position.T if check_array_orientation(position) == 'row' else position
+    position = make_orientation(position, 'column')
 
     distances = np.zeros(len(position))
     for ix, pos in enumerate(position):

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -574,7 +574,7 @@ def compute_trial_occupancy(position, timestamps, bins, start_times, stop_times,
     """
 
     bins = check_bin_definition(bins, position)
-    orientation = check_array_orientation(position) if not orientation else orientation
+    orientation = check_array_orientation(position, len(bins)) if not orientation else orientation
 
     t_speed = None
     trial_occupancy = np.zeros([len(start_times), *np.flip(bins)])

--- a/spiketools/spatial/place.py
+++ b/spiketools/spatial/place.py
@@ -147,7 +147,7 @@ def compute_trial_place_bins(spikes, position, timestamps, bins, start_times, st
     t_speed = None
 
     bins = check_bin_definition(bins, position)
-    orientation = check_array_orientation(position) if not orientation else orientation
+    orientation = check_array_orientation(position, len(bins)) if not orientation else orientation
 
     place_bins_trial = np.zeros([len(start_times), *np.flip(bins)])
     for ind, (start, stop) in enumerate(zip(start_times, stop_times)):

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -28,7 +28,7 @@ def get_position_xy(position, orientation=None):
 
     assert position.ndim == 2, "Position data must be 2d to unpack X & Y dimensions."
 
-    orientation = check_array_orientation(position) if not orientation else orientation
+    orientation = check_array_orientation(position, 2) if not orientation else orientation
 
     if orientation == 'row':
         x_data, y_data = position

--- a/spiketools/tests/spatial/test_utils.py
+++ b/spiketools/tests/spatial/test_utils.py
@@ -25,6 +25,14 @@ def test_get_position_xy():
     assert np.array_equal(x_data, expected_x)
     assert np.array_equal(y_data, expected_y)
 
+    # Test single data value cases
+    x_r1s, y_r1s = get_position_xy(np.array([[1], [5]]))
+    assert np.array_equal(x_r1s, np.array([1]))
+    assert np.array_equal(y_r1s, np.array([5]))
+    x_c1s, y_c1s = get_position_xy(np.array([[1, 5]]))
+    assert np.array_equal(x_c1s, np.array([1]))
+    assert np.array_equal(y_c1s, np.array([5]))
+
 def test_compute_nbins():
 
     # check 1d case

--- a/spiketools/tests/utils/test_checks.py
+++ b/spiketools/tests/utils/test_checks.py
@@ -72,11 +72,17 @@ def test_check_array_orientation():
     arr2c = np.array([[1, 2], [3, 4], [5, 6]])
     assert check_array_orientation(arr2c) == 'column'
 
-    # Check empty 2d arrays arrays
-    arr2re = arr2re = np.ones((2, 0))
+    # Check empty 2d arrays
+    arr2re = np.ones((2, 0))
     assert check_array_orientation(arr2re) == 'row'
-    arr2ce = arr2ce = np.ones((0, 2))
+    arr2ce = np.ones((0, 2))
     assert check_array_orientation(arr2ce) == 'column'
+
+    # Check single sample 2d arrays, with expected shape
+    arr2r1s = np.array([[1], [1]])
+    assert check_array_orientation(arr2r1s, expected=2) == 'row'
+    arr2c1s = np.array([[1, 1]])
+    assert check_array_orientation(arr2c1s, expected=2) == 'column'
 
     # Check 3d arrays
     arr3r = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])
@@ -84,11 +90,17 @@ def test_check_array_orientation():
     arr3c = np.array([[[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4], [5, 6]]])
     assert check_array_orientation(arr3c) == 'column'
 
-    # Check empty 2d arrays arrays
+    # Check empty 3d arrays
     arr3re = np.ones((1, 2, 0))
     assert check_array_orientation(arr3re) == 'row'
     arr3ce = np.ones((1, 0, 2))
     assert check_array_orientation(arr3ce) == 'column'
+
+    # Check single sample 3d arrays, with expected shape
+    arr3r1s = np.array([[[1], [1]]])
+    assert check_array_orientation(arr3r1s, expected=2) == 'row'
+    arr3c1s = np.array([[[1, 1]]])
+    assert check_array_orientation(arr3c1s, expected=2) == 'column'
 
 def test_check_array_lst_orientation():
 

--- a/spiketools/tests/utils/test_data.py
+++ b/spiketools/tests/utils/test_data.py
@@ -8,14 +8,14 @@ from spiketools.utils.data import _include_bin_edge
 ###################################################################################################
 ###################################################################################################
 
-def test_make_row_orientation():
+def test_make_orientation():
 
     arr_r = np.array([[1, 2, 3], [4, 5, 6]])
-    out_r = make_row_orientation(arr_r)
+    out_r = make_orientation(arr_r, 'row')
     assert np.array_equal(out_r, arr_r)
 
     arr_c = np.array([[1, 4], [2, 5], [3, 6]])
-    out_c = make_row_orientation(arr_c)
+    out_c = make_orientation(arr_c, 'row')
     assert np.array_equal(out_c, arr_r)
 
 def test_compute_range():

--- a/spiketools/tests/utils/test_data.py
+++ b/spiketools/tests/utils/test_data.py
@@ -11,12 +11,19 @@ from spiketools.utils.data import _include_bin_edge
 def test_make_orientation():
 
     arr_r = np.array([[1, 2, 3], [4, 5, 6]])
-    out_r = make_orientation(arr_r, 'row')
-    assert np.array_equal(out_r, arr_r)
-
     arr_c = np.array([[1, 4], [2, 5], [3, 6]])
-    out_c = make_orientation(arr_c, 'row')
-    assert np.array_equal(out_c, arr_r)
+
+    out_rr = make_orientation(arr_r, 'row')
+    assert np.array_equal(out_rr, arr_r)
+
+    out_cr = make_orientation(arr_c, 'row')
+    assert np.array_equal(out_cr, arr_r)
+
+    out_rc = make_orientation(arr_r, 'column')
+    assert np.array_equal(out_rc, arr_c)
+
+    out_cc = make_orientation(arr_c, 'column')
+    assert np.array_equal(out_cc, arr_c)
 
 def test_compute_range():
 

--- a/spiketools/utils/data.py
+++ b/spiketools/utils/data.py
@@ -11,27 +11,31 @@ from spiketools.utils.checks import check_array_orientation, check_param_options
 ###################################################################################################
 ###################################################################################################
 
-def make_row_orientation(arr, orientation=None):
-    """Check and make sure a 2d array is in row orientation.
+def make_orientation(arr, to_orientation, from_orientation=None):
+    """Check and make sure a 2d array is in a specified orientation.
 
     Parameters
     ----------
     arr : 2d array
         Array to check orientation.
-    orientation : {'row', 'column'}, optional
+    to_orientation : {'row', 'column'}
+        The desired orientation of the output data.
+        If the input is not already in this orientation, is transposed.
+    from_orientation : {'row', 'column'}, optional
         The orientation of the input array.
         If not provided, is inferred from the input data.
 
     Returns
     -------
     arr : 2d array
-        2d array in row orientation.
+        2d array in specified orientation.
     """
 
-    if not orientation:
-        orientation = check_array_orientation(arr)
+    if not from_orientation:
+        from_orientation = check_array_orientation(arr)
 
-    arr = arr.T if orientation == 'column' else arr
+    if to_orientation != from_orientation:
+        arr = arr.T
 
     return arr
 


### PR DESCRIPTION
Responds to #162 

The key issue was that because the infer the orientation of the data from the array shape / size (by assuming the # samples dimension > # values per sample), we get it wrong for this does not hold (for example, a single sample of 2D data, where the # samples < # values per sample). 

To improve our performance on this, we can use the fact that we often do know how many values per sample we expect - and so we can use that info (knowing we expected 2 values per sample allows us to make the correct call for shapes of (2, 1) or (1, 2). This update implements that and applies it across relevant places. 

I believe this effectively fixes at least most of the orientation inference, including the specific issue noted in #162, and also any situations in which position values are used in a context when we know the position dimensionality (which we can check from the bins). 

There is, I think, still one potentially unhandled case - a shape of (2, 2), where it's truly ambiguous. I don't think there really is any way to infer in this case - it would simply have to be specified - which we do allow for, so hopefully this case is not too much of an issue. 

Other related update here: changed `make_row_orientation` to `make_orientation`, such that this function can be used to enforce a specified orientation. 