### PR TITLE
[BUG] - Fix use of start_time in generator & sim func

### DIFF
--- a/spiketools/stats/generators.py
+++ b/spiketools/stats/generators.py
@@ -33,12 +33,15 @@ def poisson_generator(rate, duration, start_time=0):
     """
 
     isi = 1. / rate
+
     cur_time = start_time
-    while cur_time <= duration:
+    end_time = start_time + duration
+
+    while cur_time <= end_time:
 
         cur_time += isi * np.random.exponential()
 
-        if cur_time > duration:
+        if cur_time > end_time:
             return
 
         yield cur_time

--- a/spiketools/tests/sim/test_times.py
+++ b/spiketools/tests/sim/test_times.py
@@ -18,7 +18,19 @@ def test_sim_spiketimes_poisson():
 
     rate = 10
     duration = 2
-    times = sim_spiketimes_poisson(rate, duration)
 
+    times = sim_spiketimes_poisson(rate, duration)
     assert isinstance(times, np.ndarray)
     assert np.all(times < duration)
+
+    start_time = 2
+    times = sim_spiketimes_poisson(rate, duration, start_time)
+    assert isinstance(times, np.ndarray)
+    assert np.all(times > start_time)
+    assert np.all(times < start_time + duration)
+
+    start_time = -2
+    times = sim_spiketimes_poisson(rate, duration, start_time)
+    assert isinstance(times, np.ndarray)
+    assert np.all(times > start_time)
+    assert np.all(times < start_time + duration)

--- a/spiketools/tests/stats/test_generators.py
+++ b/spiketools/tests/stats/test_generators.py
@@ -9,9 +9,29 @@ from spiketools.stats.generators import *
 
 def test_poisson_generator():
 
-    ptrain = poisson_generator(5., 10.)
+    rate = 10
+    duration = 2
 
+    # Test as a generator
+    ptrain = poisson_generator(rate, duration)
     assert inspect.isgenerator(ptrain)
-
     val = next(ptrain)
-    assert isinstance(val, float)
+    for val in ptrain:
+        assert isinstance(val, float)
+
+    # Test collection of values matches duration range
+    outputs = np.array(list(poisson_generator(rate, duration)))
+    assert np.all(outputs > 0)
+    assert np.all(outputs < duration)
+
+    # Test collection of values matches duration range, given a start time (positive)
+    start_time = 2
+    outputs = np.array(list(poisson_generator(rate, duration, start_time)))
+    assert np.all(outputs > start_time)
+    assert np.all(outputs < start_time + duration)
+
+    # Test collection of values matches duration range, given a start time (negative)
+    start_time = -2
+    outputs = np.array(list(poisson_generator(rate, duration, start_time)))
+    assert np.all(outputs > start_time)
+    assert np.all(outputs < start_time + duration)


### PR DESCRIPTION
Previously the `start_time` input to the poisson generator wasn't used properly - it would basically change the range of the values rather than properly defining the time range to simulate over (e.g. duration=2, start_time=1 would sim from range [1, 2] instead of [1,3], and duration=2, start_time=-2 would sim [-2, 2] instead of [-2, 0]). This update fixes that, and adds additional related tests.