### PR TITLE
[ENH] - Add functionality to simulate trials

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -277,6 +277,7 @@ Functionality for simulating spiking data, available in the `sim` sub-module.
 
    sim_spiketimes
    sim_spiketrain
+   sim_trials
 
 Spike Times
 ~~~~~~~~~~~
@@ -301,6 +302,17 @@ Simulate spike trains.
    sim_spiketrain_prob
    sim_spiketrain_binom
    sim_spiketrain_poisson
+
+Trials
+~~~~~~
+
+Simulate trial-structured data.
+
+.. currentmodule:: spiketools.sim.train
+.. autosummary::
+   :toctree: generated/
+
+   sim_trials_poisson
 
 Utilities
 ~~~~~~~~~

--- a/spiketools/sim/__init__.py
+++ b/spiketools/sim/__init__.py
@@ -2,3 +2,4 @@
 
 from .times import sim_spiketimes
 from .train import sim_spiketrain
+from .trials import sim_trials

--- a/spiketools/sim/times.py
+++ b/spiketools/sim/times.py
@@ -82,4 +82,6 @@ def sim_spiketimes_poisson(rate, duration, start_time=0, refractory=0.001):
 ###################################################################################################
 ## COLLECT SIM FUNCTION OPTIONS TOGETHER
 
-SPIKETIME_FUNCS = {'poisson' : sim_spiketimes_poisson}
+SPIKETIME_FUNCS = {
+    'poisson' : sim_spiketimes_poisson,
+}

--- a/spiketools/sim/train.py
+++ b/spiketools/sim/train.py
@@ -199,6 +199,8 @@ def sim_spiketrain_poisson(rate, n_samples, fs=1000, refractory=None):
 ###################################################################################################
 ## COLLECT SIM FUNCTION OPTIONS TOGETHER
 
-SPIKETRAIN_FUNCS = {'prob' : sim_spiketrain_prob,
-                    'binom' : sim_spiketrain_binom,
-                    'poisson' : sim_spiketrain_poisson}
+SPIKETRAIN_FUNCS = {
+    'prob' : sim_spiketrain_prob,
+    'binom' : sim_spiketrain_binom,
+    'poisson' : sim_spiketrain_poisson,
+}

--- a/spiketools/sim/trials.py
+++ b/spiketools/sim/trials.py
@@ -1,0 +1,82 @@
+"""Simulate trials - 2D arrays of event related spiking activity."""
+
+import numpy as np
+
+from spiketools.sim.times import sim_spiketimes_poisson
+from spiketools.utils.checks import check_param_options
+
+###################################################################################################
+###################################################################################################
+
+def sim_trials(n_trials, method=None, time_pre=1, time_post=2, refractory=0.001, **kwargs):
+    """Simulate a collection of trials.
+
+    Parameters
+    ----------
+    n_trials : int
+        Number of trials to simulate.
+    method : {'poisson'}
+        The method to use for the simulation.
+    time_pre, time_post : float
+        The amount of time to simulate pre / post the event.
+    refractory : float, optional, default: 0.001
+        The refractory period to apply to the simulated data, in seconds.
+    **kwargs
+        Additional keyword arguments.
+        There are passed into the simulate function specified by `method`.
+
+    Returns
+    -------
+    trial_spikes : list of 1d array
+        Simulated trials, where list has length of n_trials.
+        Each simulated trial has simulated spike times for the time range [-time_pre, time_post].
+    """
+
+    check_param_options(method, 'method', ['poisson'])
+
+    trial_spikes = SPIKETRIAL_FUNCS[method](\
+        n_trials, **kwargs, time_pre=time_pre, time_post=time_post, refractory=refractory)
+
+    return trial_spikes
+
+
+###################################################################################################
+## Distribution based simulations
+
+def sim_trials_poisson(n_trials, rate_pre, rate_post, time_pre=1, time_post=2, refractory=0.001):
+    """Simulate a collection of trials, based on a Poisson spike time simulation.
+
+    Parameters
+    ----------
+    n_trials : int
+        Number of trials to simulate.
+    rate_pre, rate_post : float
+        The firing rates for the pre and post event times.
+    time_pre, time_post : float
+        The amount of time to simulate pre / post the event.
+    refractory : float, optional, default: 0.001
+        The refractory period to apply to the simulated data, in seconds.
+
+    Returns
+    -------
+    trial_spikes : list of 1d array
+        Simulated trials, where list has length of n_trials.
+        Each simulated trial has simulated spike times for the time range [-time_pre, time_post].
+    """
+
+    trial_spikes = [None] * n_trials
+    for trial_idx in range(n_trials):
+
+        trial_spikes[trial_idx] = np.append(
+            sim_spiketimes_poisson(rate_pre, time_pre, start_time=-time_pre, refractory=refractory),
+            sim_spiketimes_poisson(rate_post, time_post, start_time=0, refractory=refractory),
+        )
+
+    return trial_spikes
+
+###################################################################################################
+## COLLECT SIM FUNCTION OPTIONS TOGETHER
+
+SPIKETRIAL_FUNCS = {
+    'poisson' : sim_trials_poisson,
+}

--- a/spiketools/sim/trials.py
+++ b/spiketools/sim/trials.py
@@ -17,7 +17,7 @@ def sim_trials(n_trials, method=None, time_pre=1, time_post=2, refractory=0.001,
         Number of trials to simulate.
     method : {'poisson'}
         The method to use for the simulation.
-    time_pre, time_post : float
+    time_pre, time_post : float, optional, defaults: time_pre=1; time_post=2
         The amount of time to simulate pre / post the event.
     refractory : float, optional, default: 0.001
         The refractory period to apply to the simulated data, in seconds.
@@ -52,7 +52,7 @@ def sim_trials_poisson(n_trials, rate_pre, rate_post, time_pre=1, time_post=2, r
         Number of trials to simulate.
     rate_pre, rate_post : float
         The firing rates for the pre and post event times.
-    time_pre, time_post : float
+    time_pre, time_post : float, optional, defaults: time_pre=1; time_post=2
         The amount of time to simulate pre / post the event.
     refractory : float, optional, default: 0.001
         The refractory period to apply to the simulated data, in seconds.

--- a/spiketools/tests/sim/test_trials.py
+++ b/spiketools/tests/sim/test_trials.py
@@ -1,0 +1,37 @@
+"""Tests for spiketools.sim.trials"""
+
+from spiketools.sim.trials import *
+
+###################################################################################################
+###################################################################################################
+
+def test_sim_trials():
+
+    n_trials = 2
+    time_pre = 1
+    time_post = 2
+
+    for method, params in zip(['poisson'], [{'rate_pre' : 5, 'rate_post' : 10}]):
+
+        trials = sim_trials(n_trials, method, time_pre, time_post, **params)
+
+        assert isinstance(trials, list)
+        assert len(trials) == n_trials
+        for trial in trials:
+            assert np.all(trial > -time_pre)
+            assert np.all(trial < time_post)
+
+def test_sim_trials_poisson():
+
+    n_trials = 2
+    rate_pre = 5
+    rate_post = 10
+    time_pre = 1
+    time_post = 2
+
+    trials = sim_trials_poisson(n_trials, rate_pre, rate_post, time_pre, time_post)
+    assert isinstance(trials, list)
+    assert len(trials) == n_trials
+    for trial in trials:
+        assert np.all(trial > -time_pre)
+        assert np.all(trial < time_post)


### PR DESCRIPTION
Adds functionality to directly simulate data organized into trials. 

We already had the same motif to do this in the tutorials, and it seemed right to be made into a function. There is basically one actually simulating function (based on simulated spike times from a poisson distribution), with the overall organization organized to mimic other sim functions (that will hopefully also allow for extending to supporting other approaches for simulating trials. 