### PR TITLE
[ENH] - Update conversions and shuffles to support non-zero start time

### DIFF
--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -30,7 +30,7 @@ def convert_times_to_train(spikes, fs=1000, time_range=None):
     --------
     Convert spike times into a corresponding binary spike train:
 
-    >>> spikes = np.array([0.002, 0.250, 0.500, 0.750, 1.000, 1.250, 1.500])
+    >>> spikes = np.array([0.002, 0.250, 0.500, 0.750, 1.000, 1.250, 1.500, 2.000])
     >>> convert_times_to_train(spikes)
     array([0, 0, 1, ..., 0, 0, 1])
     """

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -63,7 +63,7 @@ def convert_train_to_times(spike_train, fs=1000, start_time=0):
         Spike train.
     fs : int, optional, default: 1000
         The sampling rate of the computed spike train, in Hz.
-    start_time : float
+    start_time : float, optional
         The initial start time for the converted spike times.
 
     Returns

--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -8,7 +8,7 @@ from spiketools.utils.checks import check_time_bins
 ###################################################################################################
 ###################################################################################################
 
-def convert_times_to_train(spikes, fs=1000, length=None):
+def convert_times_to_train(spikes, fs=1000, time_range=None):
     """Convert spike times into a binary spike train.
 
     Parameters
@@ -17,9 +17,9 @@ def convert_times_to_train(spikes, fs=1000, length=None):
         Spike times, in seconds.
     fs : int, optional, default: 1000
         The sampling rate to use for the computed spike train, in Hz.
-    length : float, optional
-        The total length of the spike train to create, in seconds.
-        If not provided, the length is set at the maximum timestamp in the input spike times.
+    time_range : list of [float, float], optional
+        Expected time range of the spikes, used to infer the length of the output spike train.
+        If not provided, the length is set as the observed time range of 'spikes'.
 
     Returns
     -------
@@ -35,8 +35,10 @@ def convert_times_to_train(spikes, fs=1000, length=None):
     array([0, 0, 1, ..., 0, 0, 1])
     """
 
-    if not length:
-        length = np.max(spikes)
+    if not time_range:
+        time_range = [np.floor(spikes[0]), np.ceil(spikes[-1])]
+
+    length = time_range[1] - time_range[0]
 
     spike_train = np.zeros(int(length * fs) + 1).astype(int)
     inds = [int(ind * fs) for ind in spikes if ind * fs <= spike_train.shape[-1]]
@@ -52,7 +54,7 @@ def convert_times_to_train(spikes, fs=1000, length=None):
     return spike_train
 
 
-def convert_train_to_times(spike_train, fs=1000):
+def convert_train_to_times(spike_train, fs=1000, start_time=0):
     """Convert a spike train representation into spike times, in seconds.
 
     Parameters
@@ -61,6 +63,8 @@ def convert_train_to_times(spike_train, fs=1000):
         Spike train.
     fs : int, optional, default: 1000
         The sampling rate of the computed spike train, in Hz.
+    start_time : float
+        The initial start time for the converted spike times.
 
     Returns
     -------
@@ -77,22 +81,22 @@ def convert_train_to_times(spike_train, fs=1000):
     """
 
     spikes = np.where(spike_train)[0] + 1
-    spikes = spikes * (1 / fs)
+    spikes = spikes * (1 / fs) + start_time
 
     return spikes
 
 
-def convert_isis_to_times(isis, offset=0, add_offset=True):
+def convert_isis_to_times(isis, add_initial=True, start_time=0):
     """Convert a sequence of inter-spike intervals to spike times.
 
     Parameters
     ----------
     isis : 1d array
         Distribution of interspike intervals, in seconds.
-    offset : float, optional
-        An offset value to add to generated spike times.
-    add_offset : bool, optional, default: True
+    add_initial : bool, optional, default: True
         Whether to prepend the offset value to the beginning of the spike times.
+    start_time : float, optional
+        The initial start time for the converted spike times.
 
     Returns
     -------
@@ -104,16 +108,14 @@ def convert_isis_to_times(isis, offset=0, add_offset=True):
     Convert a sequence of inter-spike intervals to their corresponding spike times, in seconds:
 
     >>> isis = np.array([0.3, 0.6, 0.8, 0.2, 0.7])
-    >>> convert_isis_to_times(isis, offset=0, add_offset=True)
+    >>> convert_isis_to_times(isis)
     array([0. , 0.3, 0.9, 1.7, 1.9, 2.6])
     """
 
-    spikes = np.cumsum(isis, axis=-1)
+    spikes = np.cumsum(isis, axis=-1) + start_time
 
-    if offset:
-        spikes = spikes + offset
-    if add_offset:
-        spikes = np.concatenate((np.array([offset]), spikes))
+    if add_initial:
+        spikes = np.concatenate((np.array([start_time]), spikes))
 
     return spikes
 

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -106,7 +106,7 @@ def drop_shuffle_range(func):
 
 
 @drop_shuffle_range
-def shuffle_isis(spikes, n_shuffles=1000):
+def shuffle_isis(spikes, n_shuffles=1000, start_time=0):
     """Create shuffled spike times using permuted inter-spike intervals.
 
     Parameters
@@ -115,6 +115,8 @@ def shuffle_isis(spikes, n_shuffles=1000):
         Spike times, in seconds.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
+    start_time : float, optional
+        The start time of the input spikes, used to set the time values of the shuffled outputs.
 
     Returns
     -------
@@ -134,13 +136,14 @@ def shuffle_isis(spikes, n_shuffles=1000):
 
     shuffled_spikes = np.zeros([n_shuffles, spikes.shape[-1]])
     for ind in range(n_shuffles):
-        shuffled_spikes[ind, :] = convert_isis_to_times(np.random.permutation(isis))
+        shuffled_spikes[ind, :] = convert_isis_to_times(\
+            np.random.permutation(isis), start_time=start_time)
 
     return shuffled_spikes
 
 
 @drop_shuffle_range
-def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000):
+def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000, start_time=0):
     """Shuffle spikes based on circularly shifting the spike train.
 
     Parameters
@@ -151,6 +154,8 @@ def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000):
         The minimum amount to rotate data, in terms of units of the spike train.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
+    start_time : float, optional
+        The start time of the input spikes, used to set the time values of the shuffled outputs.
 
     Returns
     -------
@@ -180,13 +185,13 @@ def shuffle_circular(spikes, shuffle_min=20000, n_shuffles=1000):
 
     for ind, shuffle in enumerate(shuffles):
         temp_train = np.roll(spike_train, shuffle)
-        shuffled_spikes[ind, :] = convert_train_to_times(temp_train)
+        shuffled_spikes[ind, :] = convert_train_to_times(temp_train) + start_time
 
     return shuffled_spikes
 
 
 @drop_shuffle_range
-def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000):
+def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000, start_time=0):
     """Shuffle data with circular shuffles of randomly sized bins of the spike train.
 
     Parameters
@@ -197,6 +202,8 @@ def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000):
         Range of bin widths in seconds from which bin sizes are randomly selected.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
+    start_time : float, optional
+        The start time of the input spikes, used to set the time values of the shuffled outputs.
 
     Returns
     -------
@@ -260,13 +267,13 @@ def shuffle_bins(spikes, bin_width_range=[.5, 7], n_shuffles=1000):
             shuffled_train[le:re] = np.roll(spike_train[le:re], shuff)
 
         # Convert back to spike times (with ms resolution) from the shuffled spike train
-        shuffled_spikes[ind, :] = convert_train_to_times(shuffled_train)
+        shuffled_spikes[ind, :] = convert_train_to_times(shuffled_train, start_time=start_time)
 
     return shuffled_spikes
 
 
 @drop_shuffle_range
-def shuffle_poisson(spikes, n_shuffles=1000):
+def shuffle_poisson(spikes, n_shuffles=1000, start_time=0):
     """Shuffle spikes based on generating new spike trains from a Poisson distribution.
 
     Parameters
@@ -275,6 +282,8 @@ def shuffle_poisson(spikes, n_shuffles=1000):
         Spike times, in seconds.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
+    start_time : float, optional
+        The start time of the input spikes, used to set the time values of the shuffled outputs.
 
     Returns
     -------
@@ -308,6 +317,6 @@ def shuffle_poisson(spikes, n_shuffles=1000):
 
     shuffled_spikes = [None] * n_shuffles
     for ind in range(n_shuffles):
-        shuffled_spikes[ind] = list(poisson_generator(rate, length)) + spikes[0]
+        shuffled_spikes[ind] = list(poisson_generator(rate, length, start_time))
 
     return shuffled_spikes

--- a/spiketools/stats/shuffle.py
+++ b/spiketools/stats/shuffle.py
@@ -14,7 +14,7 @@ from spiketools.utils.extract import drop_range, reinstate_range
 ###################################################################################################
 ###################################################################################################
 
-def shuffle_spikes(spikes, approach, n_shuffles=1000, **kwargs):
+def shuffle_spikes(spikes, approach, n_shuffles=1000, start_time=0, **kwargs):
     """Shuffle spikes.
 
     Parameters
@@ -26,6 +26,8 @@ def shuffle_spikes(spikes, approach, n_shuffles=1000, **kwargs):
         See shuffle sub-functions for details.
     n_shuffles : int, optional, default: 1000
         The number of shuffles to create.
+    start_time : float, optional
+        The start time of the input spikes, used to set the time values of the shuffled outputs.
     kwargs
         Additional keyword arguments for the shuffle procedure.
         See shuffle sub-functions for details.
@@ -56,14 +58,16 @@ def shuffle_spikes(spikes, approach, n_shuffles=1000, **kwargs):
 
     check_param_options(approach, 'approach', ['isi', 'circular', 'bincirc'])
 
+    shared_kwargs = {'n_shuffles' : n_shuffles, 'start_time' : start_time}
+
     if approach == 'isi':
-        shuffled_spikes = shuffle_isis(spikes, n_shuffles=n_shuffles)
+        shuffled_spikes = shuffle_isis(spikes, **shared_kwargs)
 
     elif approach == 'circular':
-        shuffled_spikes = shuffle_circular(spikes, n_shuffles=n_shuffles, **kwargs)
+        shuffled_spikes = shuffle_circular(spikes, **shared_kwargs, **kwargs)
 
     elif approach == 'bincirc':
-        shuffled_spikes = shuffle_bins(spikes, n_shuffles=n_shuffles, **kwargs)
+        shuffled_spikes = shuffle_bins(spikes, **shared_kwargs, **kwargs)
 
     return shuffled_spikes
 

--- a/spiketools/tests/conftest.py
+++ b/spiketools/tests/conftest.py
@@ -36,8 +36,16 @@ def check_dir():
 @pytest.fixture(scope='session')
 def tspikes():
 
-    yield np.array([0.5, 1.5, 2., 2.5, 3., 3.75, 4., 4.25,
-                    5., 5.5, 5.75, 6., 7., 7.5, 8.])
+    yield np.array([0.5, 1.5, 2.0, 2.5, 3.0, 3.2, 3.7, 4.0, 4.2, 4.7,
+                    5.0, 5.7, 6.0, 7.0, 7.5, 8.0, 8.2, 8.7, 9.2, 9.9])
+
+@pytest.fixture(scope='session')
+def tspikes_offset():
+
+    tspikes = np.array([0.5, 1.5, 2.0, 2.5, 3.0, 3.2, 3.7, 4.0, 4.2, 4.7,
+                        5.0, 5.7, 6.0, 7.0, 7.5, 8.0, 8.2, 8.7, 9.2, 9.9])
+
+    yield tspikes - 5
 
 @pytest.fixture(scope='session')
 def ttrial_spikes():

--- a/spiketools/tests/measures/test_conversions.py
+++ b/spiketools/tests/measures/test_conversions.py
@@ -18,6 +18,19 @@ def test_convert_times_to_train(tspikes):
     assert spike_train.shape[-1] > tspikes.shape[-1]
     assert sum(spike_train) == tspikes.shape[-1]
 
+    # Test with non-zero start time
+    spike_train2 = convert_times_to_train(tspikes - 3)
+    assert isinstance(spike_train2, np.ndarray)
+    assert sum(spike_train2) == tspikes.shape[-1]
+    assert len(spike_train2) == len(spike_train)
+
+    # Test with specified time_range
+    time_range = [-2, 10]
+    spike_train3 = convert_times_to_train(tspikes - 1, time_range=time_range)
+    assert isinstance(spike_train3, np.ndarray)
+    assert sum(spike_train3) == tspikes.shape[-1]
+    assert len(spike_train3) == 1000 * (time_range[1] - time_range[0]) + 1
+
     # Check the error with times / sampling rate mismatch
     spikes = np.array([0.1000, 0.1500, 0.1505, 0.2000])
     with raises(ValueError):
@@ -42,6 +55,14 @@ def test_convert_train_to_times():
     assert spikes.shape[-1] == spike_inds.shape[-1]
     assert np.array_equal(spikes, expected * 2)
 
+    # Check different start times, including positive and negative start time offsets
+    start_time = 2
+    spikes = convert_train_to_times(train, fs=500, start_time=start_time)
+    spikes == expected + start_time
+    start_time = -2
+    spikes = convert_train_to_times(train, fs=500, start_time=start_time)
+    spikes == expected + start_time
+
 def test_convert_isis_to_times(tspikes):
 
     isis = compute_isis(tspikes)
@@ -49,13 +70,13 @@ def test_convert_isis_to_times(tspikes):
     spikes1 = convert_isis_to_times(isis)
     assert spikes1.shape[-1] == tspikes.shape[-1]
 
-    spikes2 = convert_isis_to_times(isis, offset=2.)
+    spikes2 = convert_isis_to_times(isis, start_time=2.)
     assert spikes2[0] == 2.
 
-    spikes3 = convert_isis_to_times(isis, add_offset=False)
+    spikes3 = convert_isis_to_times(isis, add_initial=False)
     assert len(spikes3) == len(isis)
 
-    spikes4 = convert_isis_to_times(isis, offset=tspikes[0])
+    spikes4 = convert_isis_to_times(isis, start_time=tspikes[0])
     assert np.array_equal(spikes4, tspikes)
 
 def test_convert_times_to_counts(tspikes):

--- a/spiketools/tests/measures/test_conversions.py
+++ b/spiketools/tests/measures/test_conversions.py
@@ -11,7 +11,7 @@ from spiketools.measures.conversions import *
 ###################################################################################################
 ###################################################################################################
 
-def test_convert_times_to_train(tspikes):
+def test_convert_times_to_train(tspikes, tspikes_offset):
 
     spike_train = convert_times_to_train(tspikes)
     assert isinstance(spike_train, np.ndarray)
@@ -19,14 +19,14 @@ def test_convert_times_to_train(tspikes):
     assert sum(spike_train) == tspikes.shape[-1]
 
     # Test with non-zero start time
-    spike_train2 = convert_times_to_train(tspikes - 3)
+    spike_train2 = convert_times_to_train(tspikes_offset)
     assert isinstance(spike_train2, np.ndarray)
     assert sum(spike_train2) == tspikes.shape[-1]
     assert len(spike_train2) == len(spike_train)
 
     # Test with specified time_range
-    time_range = [-2, 10]
-    spike_train3 = convert_times_to_train(tspikes - 1, time_range=time_range)
+    time_range = [-10, 10]
+    spike_train3 = convert_times_to_train(tspikes_offset, time_range=time_range)
     assert isinstance(spike_train3, np.ndarray)
     assert sum(spike_train3) == tspikes.shape[-1]
     assert len(spike_train3) == 1000 * (time_range[1] - time_range[0]) + 1

--- a/spiketools/tests/measures/test_spikes.py
+++ b/spiketools/tests/measures/test_spikes.py
@@ -9,7 +9,7 @@ from spiketools.measures.spikes import *
 
 def test_compute_firing_rate(tspikes):
 
-    rate = compute_firing_rate(tspikes)
+    rate = compute_firing_rate(tspikes, time_range=[0, 10])
 
     assert isinstance(rate, float)
     assert np.isclose(rate, 2.0)
@@ -19,8 +19,8 @@ def test_compute_isis(tspikes):
     isis = compute_isis(tspikes)
     assert isinstance(isis, np.ndarray)
     assert isis.shape[-1] + 1 == tspikes.shape[-1]
-    assert np.allclose(isis, np.array([1.0, 0.5, 0.5, 0.5, 0.75, 0.25, 0.25,
-                                       0.75, 0.5, 0.25, 0.25, 1.0, 0.5, 0.5]))
+    assert np.allclose(isis, np.array([1.0, 0.5, 0.5, 0.5, 0.2, 0.5, 0.3, 0.2, 0.5, 0.3,
+                                       0.7, 0.3, 1.0, 0.5, 0.5, 0.2, 0.5, 0.5, 0.7]))
     assert sum(isis < 0) == 0
 
 def test_compute_cv():

--- a/spiketools/tests/stats/test_shuffle.py
+++ b/spiketools/tests/stats/test_shuffle.py
@@ -42,8 +42,21 @@ def test_drop_shuffle_range():
     #   This test the spikes that get moved from the empty range (spikes @ ind: [1, 2])
     drop_time_range = [2, 4]
     out = _shuffle_spikes(spikes, n_shuffles, drop_time_range=drop_time_range)
-    toutput = np.array([0.5, 3.5, 3.9, 4.1, 5.4, 5.9])
-    assert np.allclose(out, np.array([toutput + 1] * n_shuffles))
+    toutput = np.array([1.5, 4.5, 4.9, 5.1, 6.4, 6.9])
+    assert np.allclose(out, np.array([toutput] * n_shuffles))
+
+    # Test that this all still works with negative values / different start time
+    spikes_off = np.array([-1.5, -1.1, -0.5, 0.1, 0.7, 4.1, 5.1])
+
+    # Check without activating decorator
+    out_off_no_drop = _shuffle_spikes(spikes_off, n_shuffles)
+    assert np.allclose(out_off_no_drop, np.array([spikes_off + 1] * n_shuffles))
+
+    # Check with activating decorator
+    drop_time_range_off = [1, 4]
+    out_off = _shuffle_spikes(spikes_off, n_shuffles, drop_time_range=drop_time_range_off)
+    toutput_off = np.array([-0.5, -0.1, 0.5, 4.1, 4.7, 5.1, 6.1])
+    assert np.allclose(out_off, np.array([toutput_off] * n_shuffles))
 
 def test_shuffle_isis(tspikes, tspikes_offset):
 

--- a/spiketools/tests/stats/test_shuffle.py
+++ b/spiketools/tests/stats/test_shuffle.py
@@ -10,14 +10,19 @@ from spiketools.stats.shuffle import *
 ###################################################################################################
 ###################################################################################################
 
-def test_shuffle_spikes(tspikes):
+def test_shuffle_spikes(tspikes, tspikes_offset):
 
+    n_shuffles = 2
     approaches = ['ISI', 'CIRCULAR', 'BINCIRC']
     kwargs = [{}, {'shuffle_min' : 10}, {}]
 
-    for approach, kwarg in zip(approaches, kwargs):
-        shuffled = shuffle_spikes(tspikes, approach=approach, n_shuffles=1, **kwarg)
-        assert isinstance(shuffled, np.ndarray)
+    for tdata in [tspikes, tspikes_offset]:
+        for approach, kwarg in zip(approaches, kwargs):
+            shuffled = shuffle_spikes(tdata, approach=approach, n_shuffles=n_shuffles, **kwarg)
+            assert isinstance(shuffled, np.ndarray)
+            assert len(shuffled) == n_shuffles
+            for el in shuffled:
+                assert len(el) == len(tdata)
 
 def test_drop_shuffle_range():
 
@@ -40,7 +45,7 @@ def test_drop_shuffle_range():
     toutput = np.array([0.5, 3.5, 3.9, 4.1, 5.4, 5.9])
     assert np.allclose(out, np.array([toutput + 1] * n_shuffles))
 
-def test_shuffle_isis(tspikes):
+def test_shuffle_isis(tspikes, tspikes_offset):
 
     shuffled = shuffle_isis(tspikes, n_shuffles=1)
     assert isinstance(shuffled, np.ndarray)
@@ -54,12 +59,17 @@ def test_shuffle_isis(tspikes):
     out2 = shuffle_isis(tspikes, n_shuffles=1)
     assert not np.array_equal(out1, out2)
 
+    # Test spikes with start time
+    shuffled_start = shuffle_isis(tspikes_offset, n_shuffles=1, start_time=-5)
+    assert tspikes.shape[-1] == shuffled_start.shape[-1]
+    assert np.min(shuffled_start) < 0
+
     # Test with more shuffles
     n_shuffles = 5
     out_many = shuffle_isis(tspikes, n_shuffles=n_shuffles)
     assert out_many.shape == (n_shuffles, len(tspikes))
 
-def test_shuffle_circular(tspikes):
+def test_shuffle_circular(tspikes, tspikes_offset):
 
     shuffled = shuffle_circular(tspikes, 10, n_shuffles=1)
     assert isinstance(shuffled, np.ndarray)
@@ -73,12 +83,17 @@ def test_shuffle_circular(tspikes):
     out2 = shuffle_circular(tspikes, 10, n_shuffles=1)
     assert not np.array_equal(out1, out2)
 
+    # Test start time
+    shuffled_start = shuffle_circular(tspikes_offset, 10, n_shuffles=1, start_time=-5)
+    assert tspikes.shape[-1] == shuffled_start.shape[-1]
+    assert np.min(shuffled_start) < 0
+
     # Test with more shuffles
     n_shuffles = 5
     out_many = shuffle_circular(tspikes, 10, n_shuffles=n_shuffles)
     assert out_many.shape == (n_shuffles, len(tspikes))
 
-def test_shuffle_bins(tspikes):
+def test_shuffle_bins(tspikes, tspikes_offset):
 
     shuffled = shuffle_bins(tspikes, n_shuffles=1)
     assert isinstance(shuffled, np.ndarray)
@@ -92,12 +107,17 @@ def test_shuffle_bins(tspikes):
     out2 = shuffle_bins(tspikes, n_shuffles=1)
     assert not np.array_equal(out1, out2)
 
+    # Test start time
+    shuffled_start = shuffle_bins(tspikes_offset, n_shuffles=1, start_time=-5)
+    assert tspikes.shape[-1] == shuffled_start.shape[-1]
+    assert np.min(shuffled_start) < 0
+
     # Test with more shuffles
     n_shuffles = 5
     out_many = shuffle_bins(tspikes, n_shuffles=n_shuffles)
     assert out_many.shape == (n_shuffles, len(tspikes))
 
-def test_shuffle_poisson(tspikes):
+def test_shuffle_poisson(tspikes, tspikes_offset):
 
     shuffled = shuffle_poisson(tspikes)
     assert isinstance(shuffled, list)
@@ -107,6 +127,10 @@ def test_shuffle_poisson(tspikes):
     out1 = shuffle_poisson(tspikes, n_shuffles=1)
     out2 = shuffle_poisson(tspikes, n_shuffles=1)
     assert not np.array_equal(out1, out2)
+
+    # Test start time
+    shuffled_start = shuffle_poisson(tspikes_offset, n_shuffles=1, start_time=-5)
+    assert np.min(shuffled_start[0]) < 0
 
     # Test with more shuffles
     #   Note: checks the # of shuffles, but not the exact # of spikes, which is not guaranteed


### PR DESCRIPTION
Several conversion and shuffle function basically assume that the time range of a set of spike times is something like [0, end_time]. This creates an issue if you want to use these functions with a set of spike times that is not like this, and is instead [start_time, end_time], whereby start_time could be a positive or negative number. 

This PR updates conversion and shuffle functions to support such a case. 

For example, given the following set of spike times:
```
# Example spikes from a single example trial around event time zero
tspikes [-1.5, -0.5, 0.75, 1.1, 1.5]
```

Previously, the spike train conversion for this would not be correct (it would end up length 1.5 seconds instead of 3), and relatedly, shuffling wouldn't work properly. By updating some data checks to check for ranges that might not start at time 0, and adding either a `time_range` or `start_time` input to several functions, this update means that these processes should now work on such data. 