### PR TITLE
[BUG] - Fix converting times -> train with positive start time offset

### DIFF
--- a/spiketools/measures/conversions.py
+++ b/spiketools/measures/conversions.py
@@ -41,7 +41,7 @@ def convert_times_to_train(spikes, fs=1000, time_range=None):
     length = time_range[1] - time_range[0]
 
     spike_train = np.zeros(int(length * fs) + 1).astype(int)
-    inds = [int(ind * fs) for ind in spikes if ind * fs <= spike_train.shape[-1]]
+    inds = [int(ind * fs) for ind in spikes - time_range[0] if ind * fs <= spike_train.shape[-1]]
     spike_train[inds] = 1
 
     # Check that the spike times are fully encoded into the spike train

--- a/spiketools/tests/conftest.py
+++ b/spiketools/tests/conftest.py
@@ -33,19 +33,25 @@ def check_dir():
 
 ## TEST OBJECTS
 
+def get_tspikes():
+
+    return np.array([0.5, 1.5, 2.0, 2.5, 3.0, 3.2, 3.7, 4.0, 4.2, 4.7,
+                     5.0, 5.7, 6.0, 7.0, 7.5, 8.0, 8.2, 8.7, 9.2, 9.9])
+
 @pytest.fixture(scope='session')
 def tspikes():
 
-    yield np.array([0.5, 1.5, 2.0, 2.5, 3.0, 3.2, 3.7, 4.0, 4.2, 4.7,
-                    5.0, 5.7, 6.0, 7.0, 7.5, 8.0, 8.2, 8.7, 9.2, 9.9])
+    yield get_tspikes()
 
 @pytest.fixture(scope='session')
-def tspikes_offset():
+def tspikes_offset_neg():
 
-    tspikes = np.array([0.5, 1.5, 2.0, 2.5, 3.0, 3.2, 3.7, 4.0, 4.2, 4.7,
-                        5.0, 5.7, 6.0, 7.0, 7.5, 8.0, 8.2, 8.7, 9.2, 9.9])
+    yield get_tspikes() - 5
 
-    yield tspikes - 5
+@pytest.fixture(scope='session')
+def tspikes_offset_pos():
+
+    yield get_tspikes() + 5
 
 @pytest.fixture(scope='session')
 def ttrial_spikes():

--- a/spiketools/tests/measures/test_conversions.py
+++ b/spiketools/tests/measures/test_conversions.py
@@ -11,25 +11,26 @@ from spiketools.measures.conversions import *
 ###################################################################################################
 ###################################################################################################
 
-def test_convert_times_to_train(tspikes, tspikes_offset):
+def test_convert_times_to_train(tspikes, tspikes_offset_neg, tspikes_offset_pos):
 
     spike_train = convert_times_to_train(tspikes)
     assert isinstance(spike_train, np.ndarray)
     assert spike_train.shape[-1] > tspikes.shape[-1]
     assert sum(spike_train) == tspikes.shape[-1]
 
-    # Test with non-zero start time
-    spike_train2 = convert_times_to_train(tspikes_offset)
-    assert isinstance(spike_train2, np.ndarray)
-    assert sum(spike_train2) == tspikes.shape[-1]
-    assert len(spike_train2) == len(spike_train)
+    # Test with offset spike times
+    for tspikes_offset in [tspikes_offset_neg, tspikes_offset_pos]:
+        spike_train_off = convert_times_to_train(tspikes_offset)
+        assert isinstance(spike_train_off, np.ndarray)
+        assert sum(spike_train_off) == tspikes.shape[-1]
+        assert len(spike_train_off) == len(spike_train)
 
-    # Test with specified time_range
+    # Test with specified time_ranges - using negative offset spike times
     time_range = [-10, 10]
-    spike_train3 = convert_times_to_train(tspikes_offset, time_range=time_range)
-    assert isinstance(spike_train3, np.ndarray)
-    assert sum(spike_train3) == tspikes.shape[-1]
-    assert len(spike_train3) == 1000 * (time_range[1] - time_range[0]) + 1
+    spike_train_tr = convert_times_to_train(tspikes_offset_neg, time_range=time_range)
+    assert isinstance(spike_train_tr, np.ndarray)
+    assert sum(spike_train_tr) == tspikes.shape[-1]
+    assert len(spike_train_tr) == 1000 * (time_range[1] - time_range[0]) + 1
 
     # Check the error with times / sampling rate mismatch
     spikes = np.array([0.1000, 0.1500, 0.1505, 0.2000])

--- a/spiketools/tests/stats/test_shuffle.py
+++ b/spiketools/tests/stats/test_shuffle.py
@@ -96,7 +96,7 @@ def test_shuffle_isis(tspikes, tspikes_offset_neg, tspikes_offset_pos):
     assert tspikes.shape[-1] == shuffled_off_pos.shape[-1]
     assert np.min(shuffled_off_pos) >= 5
 
-def test_shuffle_circular(tspikes, tspikes_offset):
+def test_shuffle_circular(tspikes, tspikes_offset_neg, tspikes_offset_pos):
 
     shuffled = shuffle_circular(tspikes, 10, n_shuffles=1)
     assert isinstance(shuffled, np.ndarray)


### PR DESCRIPTION
This fixes a bug related to #191, where we added support for conversions and shuffles with non-zero start times. 

The issue is that I added tests for negative start times, but not start time offsets > 0, with the bug being that due to the length check in `convert_times_to_train`, this could lead to spikes getting cut off, and so not properly encoding the spike train (which could also lead to failures in shuffling). 

This update fixes that - making sure the times -> train procedure tracks the length of the spike times considering the spike time cut off, rather than erroneously cutting off (for example, previously a spike range between 5-15, with length 10, would cut of spike times after time value 10). 

The actual fix here is a small change to the convert function - the rest of the PR is updates to test to test this procedure.