### PR TITLE
[MNT] - Update computing place measures for thresholding

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -549,6 +549,8 @@ Utilities for extracting data segments of interest.
    :toctree: generated/
 
    create_mask
+   create_nan_mask
+   select_from_arrays
    get_range
    get_value_range
    get_ind_by_value

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -322,7 +322,7 @@ def create_position_df(position, timestamps, bins, area_range=None, speed=None,
     area_range : list of list, optional
         Edges of the area to bin, defined as [[x_min, x_max], [y_min, y_max]].
     speed : 1d array, optional
-        Current speed for each position.
+        Speed values corresponding to each position.
         Should be the same length as timestamps.
     min_speed, max_speed : float, optional
         Minimum and/or maximum speed thresholds to apply.
@@ -448,7 +448,7 @@ def compute_occupancy(position, timestamps, bins, area_range=None, speed=None,
     area_range : list of list, optional
         Edges of the area to bin, defined as [[x_min, x_max], [y_min, y_max]].
     speed : 1d array, optional
-        Current speed for each position.
+        Speed values corresponding to each position.
         Should be the same length as timestamps.
     min_speed, max_speed : float, optional
         Minimum and/or maximum speed thresholds to apply.
@@ -524,7 +524,7 @@ def compute_trial_occupancy(position, timestamps, bins, start_times, stop_times,
     area_range : list of list, optional
         Edges of the area to bin, defined as [[x_min, x_max], [y_min, y_max]].
     speed : 1d array, optional
-        Current speed for each position.
+        Speed values corresponding to each position.
         Should be the same length as timestamps.
     min_speed, max_speed : float, optional
         Minimum and/or maximum speed thresholds to apply.

--- a/spiketools/spatial/occupancy.py
+++ b/spiketools/spatial/occupancy.py
@@ -54,6 +54,7 @@ def compute_bin_edges(position, bins, area_range=None):
     """
 
     bins = check_bin_definition(bins, position)
+    position = position if not position is None else np.array([])
 
     if len(bins) == 1:
 
@@ -63,8 +64,7 @@ def compute_bin_edges(position, bins, area_range=None):
 
     elif len(bins) == 2:
 
-        x_pos, y_pos = get_position_xy(position) \
-            if isinstance(position, np.ndarray) else (None, None)
+        x_pos, y_pos = get_position_xy(position) if position.size else (None, None)
         x_range, y_range = area_range if isinstance(area_range, list) else (None, None)
 
         x_edges = np.histogram_bin_edges(x_pos, bins=bins[0], range=x_range)

--- a/spiketools/spatial/place.py
+++ b/spiketools/spatial/place.py
@@ -13,7 +13,7 @@ from spiketools.utils.extract import (get_range, get_values_by_time_range, get_v
 ###################################################################################################
 
 def compute_place_bins(spikes, position, timestamps, bins, area_range=None,
-                       speed=None, speed_threshold=None, time_threshold=None,
+                       speed=None, min_speed=None, max_speed=None, time_threshold=None,
                        occupancy=None, orientation=None):
     """Compute the spatially binned spiking activity.
 
@@ -31,11 +31,11 @@ def compute_place_bins(spikes, position, timestamps, bins, area_range=None,
     area_range : list of list, optional
         Edges of the area to bin, defined as [[x_min, x_max], [y_min, y_max]].
     speed : 1d array, optional
-        Current speed for each position.
+        Speed values corresponding to each position.
         Should be the same length as timestamps.
-    speed_threshold : float, optional
-        Speed threshold to apply.
-        If provided, any position values with an associated speed below this value are dropped.
+    min_speed, max_speed : float, optional
+        Minimum and/or maximum speed thresholds to apply.
+        Any spikes with an associated speed below the minimum or above maximum are dropped.
     time_threshold : float, optional
         A maximum time threshold, per bin observation, to apply.
         If provided, any bin values with an associated time length above this value are dropped.
@@ -67,7 +67,7 @@ def compute_place_bins(spikes, position, timestamps, bins, area_range=None,
 
     if speed is not None:
         spikes = threshold_spikes_by_values(\
-            spikes, timestamps, speed, speed_threshold, time_threshold)
+            spikes, timestamps, speed, min_speed, max_speed, time_threshold)
 
     spike_positions = get_values_by_times(timestamps, position, spikes, time_threshold)
     place_bins = compute_bin_counts_pos(spike_positions, bins, area_range, occupancy, orientation)
@@ -76,8 +76,9 @@ def compute_place_bins(spikes, position, timestamps, bins, area_range=None,
 
 
 def compute_trial_place_bins(spikes, position, timestamps, bins, start_times, stop_times,
-                             area_range=None, speed=None, speed_threshold=None, time_threshold=None,
-                             trial_occupancy=None, flatten=False, orientation=None):
+                             area_range=None, speed=None, min_speed=None, max_speed=None,
+                             time_threshold=None, trial_occupancy=None, flatten=False,
+                             orientation=None):
     """Compute the spatially binned spiking activity, across trials.
 
     Parameters
@@ -96,11 +97,11 @@ def compute_trial_place_bins(spikes, position, timestamps, bins, start_times, st
     area_range : list of list, optional
         Edges of the area to bin, defined as [[x_min, x_max], [y_min, y_max]].
     speed : 1d array, optional
-        Current speed for each position.
+        Speed values corresponding to each position.
         Should be the same length as timestamps.
-    speed_threshold : float, optional
-        Speed threshold to apply.
-        If provided, any position values with an associated speed below this value are dropped.
+    min_speed, max_speed : float, optional
+        Minimum and/or maximum speed thresholds to apply.
+        Any spikes with an associated speed below the minimum or above maximum are dropped.
     time_threshold : float, optional
         A maximum time threshold, per bin observation, to apply.
         If provided, any bin values with an associated time length above this value are dropped.
@@ -161,7 +162,7 @@ def compute_trial_place_bins(spikes, position, timestamps, bins, start_times, st
             t_occ = trial_occupancy[ind, :]
 
         place_bins_trial[ind, :] = compute_place_bins(t_spikes, t_pos, t_times, bins, area_range,
-                                                      t_speed, speed_threshold, time_threshold,
+                                                      t_speed, min_speed, max_speed, time_threshold,
                                                       t_occ, orientation)
 
     if flatten:

--- a/spiketools/tests/spatial/test_place.py
+++ b/spiketools/tests/spatial/test_place.py
@@ -25,9 +25,9 @@ def test_compute_place_bins():
 
     # Check with speed dropping
     speed = np.array([0, 1, 1, 1, 0, 1, 1, 0, 1, 1])
-    speed_threshold = 0.5
+    min_speed = 0.5
     place_bins = compute_place_bins(spikes, position, timestamps, bins,
-                                    speed=speed, speed_threshold=speed_threshold)
+                                    speed=speed, min_speed=min_speed)
     expected = np.array([[3, 0], [0, 2], [0, 2]])
     assert np.array_equal(place_bins, expected)
 
@@ -51,10 +51,10 @@ def test_compute_trial_place_bins():
 
     # Check with speed dropping
     speed = np.array([0, 1, 1, 1, 0, 1, 1, 0, 1, 1])
-    speed_threshold = 0.5
+    min_speed = 0.5
     place_bins_trial = compute_trial_place_bins(spikes, position, timestamps, bins,
                                                 start_times, stop_times,
-                                                speed=speed, speed_threshold=speed_threshold)
+                                                speed=speed, min_speed=min_speed)
     expected = np.array([[[0, 0], [0, 3], [0, 0]],
                          [[0, 2], [0, 0], [0, 2]]])
     assert np.array_equal(place_bins_trial, expected)

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -191,11 +191,27 @@ def test_get_values_by_times():
     assert len(outputs) == len(timepoints)
     assert np.array_equal(outputs, np.array([8, 6]))
 
+    # Test with time_threshold
+    out_thresh = get_values_by_times(times, values_1d, timepoints, time_threshold=0.2)
+    assert np.array_equal(out_thresh, np.array([6]))
+
+    # Test without null dropping
+    out_thresh_null = get_values_by_times(times, values_1d, timepoints,
+                                          time_threshold=0.2, drop_null=False)
+    assert np.array_equal(out_thresh_null, np.array([np.nan, 6]), equal_nan=True)
+
     # Test 2d extraction (row data)
     values_2d = np.array([[5, 8, 4, 6, 7], [5, 8, 4, 6, 7]])
     outputs = get_values_by_times(times, values_2d, timepoints)
     assert len(outputs) == len(timepoints)
     assert np.array_equal(outputs, np.array([[8, 6], [8, 6]]))
+
+    # Time threshold & null dropping for 2d
+    out_thresh_2d = get_values_by_times(times, values_2d, timepoints, time_threshold=0.2)
+    assert np.array_equal(out_thresh_2d, np.array([[6], [6]]))
+    out_thresh_null_2d = get_values_by_times(times, values_2d, timepoints,
+                                             time_threshold=0.2, drop_null=False)
+    assert np.array_equal(out_thresh_null_2d, np.array([[np.nan, 6], [np.nan, 6]]), equal_nan=True)
 
     # Test 2d extraction (column data)
     outputs = get_values_by_times(times, values_2d.T, timepoints)
@@ -205,6 +221,10 @@ def test_get_values_by_times():
     # Test empty extraction
     outputs_empty = get_values_by_times(times, values_1d, np.array([]))
     assert len(outputs_empty) == 0
+
+    # Special case - test single element case
+    outputs_1 = get_values_by_times(times, values_1d, np.array([2.0]), drop_null=False)
+    assert len(outputs_1) == 1
 
 def test_get_values_by_time_range():
 

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -201,13 +201,16 @@ def test_threshold_spikes_by_values():
     spikes = np.array([0.5, 1., 1.5, 2., 2.5])
     times = np.array([0.5, 1.1, 1.9, 2.4])
     values = np.array([0, 1, 1, 0])
-    tthresh = 0.25
-    dthresh = 0.5
 
-    out1 = threshold_spikes_by_values(spikes, times, values, dthresh, tthresh, data_comparison='greater')
+    time_thresh = 0.25
+    data_thresh = 0.5
+
+    out1 = threshold_spikes_by_values(\
+        spikes, times, values, min_value=data_thresh, time_threshold=time_thresh)
     assert np.array_equal(out1, np.array([1., 2.]))
 
-    out2 = threshold_spikes_by_values(spikes, times, values, dthresh, tthresh, data_comparison='less')
+    out2 = threshold_spikes_by_values(\
+        spikes, times, values, max_value=data_thresh, time_threshold=time_thresh)
     assert np.array_equal(out2, np.array([0.5, 2.5]))
 
 def test_drop_range():

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -117,8 +117,8 @@ def test_get_ind_by_time():
     assert get_ind_by_time(times, 3.25) == 2
 
     # test with threshold
-    assert get_ind_by_time(times, 3.15, threshold=0.25) == 2
-    assert get_ind_by_time(times, 3.5, threshold=0.25) == -1
+    assert get_ind_by_time(times, 3.15, time_threshold=0.25) == 2
+    assert get_ind_by_time(times, 3.5, time_threshold=0.25) == -1
 
 def test_get_inds_by_values():
 
@@ -147,9 +147,9 @@ def test_get_inds_by_times():
     assert np.array_equal(inds, np.array([2, 3]))
 
     extract = [3.5, 4.15, 4.85]
-    inds = get_inds_by_times(times, extract, threshold=0.25, drop_null=True)
+    inds = get_inds_by_times(times, extract, time_threshold=0.25, drop_null=True)
     np.array_equal(inds, np.array([np.nan, 3, 4]), equal_nan=True)
-    inds = get_inds_by_times(times, extract, threshold=0.25, drop_null=False)
+    inds = get_inds_by_times(times, extract, time_threshold=0.25, drop_null=False)
     np.array_equal(inds, np.array([3, 4]), equal_nan=True)
 
 def test_get_value_by_time():

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -138,6 +138,10 @@ def test_get_inds_by_values():
     with raises(AssertionError):
         ind = get_ind_by_time(values, np.nan)
 
+    # Test empty extraction
+    inds_empty = get_inds_by_values(values, np.array([]))
+    assert len(inds_empty) == 0
+
 def test_get_inds_by_times():
 
     times = np.array([1, 2, 3, 4, 5])
@@ -151,6 +155,10 @@ def test_get_inds_by_times():
     np.array_equal(inds, np.array([np.nan, 3, 4]), equal_nan=True)
     inds = get_inds_by_times(times, extract, time_threshold=0.25, drop_null=False)
     np.array_equal(inds, np.array([3, 4]), equal_nan=True)
+
+    # Test empty extraction
+    inds_empty = get_inds_by_times(times, np.array([]))
+    assert len(inds_empty) == 0
 
 def test_get_value_by_time():
 
@@ -194,6 +202,10 @@ def test_get_values_by_times():
     assert len(outputs) == len(timepoints)
     assert np.array_equal(outputs, np.array([[8, 6], [8, 6]]).T)
 
+    # Test empty extraction
+    outputs_empty = get_values_by_times(times, values_1d, np.array([]))
+    assert len(outputs_empty) == 0
+
 def test_get_values_by_time_range():
 
     times = np.array([1, 2, 3, 4, 5])
@@ -226,6 +238,10 @@ def test_threshold_spikes_by_times():
     assert isinstance(out, np.ndarray)
     assert np.array_equal(out, np.array([0.5, 1., 2.]))
 
+    # Test empty extraction
+    out_empty = threshold_spikes_by_times(np.array([]), times, threshold)
+    assert len(out_empty) == 0
+
 def test_threshold_spikes_by_values():
 
     spikes = np.array([0.5, 1., 1.5, 2., 2.5])
@@ -242,6 +258,10 @@ def test_threshold_spikes_by_values():
     out2 = threshold_spikes_by_values(\
         spikes, times, values, max_value=data_thresh, time_threshold=time_thresh)
     assert np.array_equal(out2, np.array([0.5, 2.5]))
+
+    # Test empty extraction
+    out_empty = threshold_spikes_by_values(np.array([]), times, values, min_value=data_thresh)
+    assert len(out_empty) == 0
 
 def test_drop_range():
 
@@ -265,10 +285,10 @@ def test_drop_range():
     assert spikes.shape == out.shape
     assert np.allclose(out, np.array([0.5, 1.5, 1.9, 2.1, 3.4, 3.9, 4.2, 5.7]))
 
-    # check that it works if passed an empty time range
+    # Test empty extraction
     time_range = []
-    out = drop_range(spikes, time_range)
-    assert np.array_equal(out, spikes)
+    out_empty = drop_range(spikes, time_range)
+    assert np.array_equal(out_empty, spikes)
 
 def test_reinstate_range_1d():
 

--- a/spiketools/tests/utils/test_extract.py
+++ b/spiketools/tests/utils/test_extract.py
@@ -37,6 +37,36 @@ def test_create_mask():
     mask2 = create_mask(data, min_value2, max_value2)
     assert np.array_equal(mask2, np.array([False, True, True, False, False]))
 
+def test_create_nan_mask():
+
+    data = np.array([0.5, 1.0, np.nan, 1.5, 2.0, np.nan, 2.5])
+    mask = create_nan_mask(data)
+    assert np.array_equal(mask, np.array([True, True, False, True, True, False, True]))
+
+def test_select_from_arrays():
+
+    data1 = np.array([1, 2, 3, 4])
+    data2 = np.array([5, 6, 7, 8])
+    data3 = np.array([9, 10, 11, 12])
+
+    mask = np.array([False, True, False, True])
+
+    expected1 = np.array([2, 4])
+    expected2 = np.array([6, 8])
+    expected3 = np.array([10, 12])
+
+    out1 = select_from_arrays(mask, data1)
+    assert np.array_equal(out1, expected1)
+
+    out1a, out2a = select_from_arrays(mask, data1, data2)
+    assert np.array_equal(out1a, expected1)
+    assert np.array_equal(out2a, expected2)
+
+    out1b, out2b, out3b = select_from_arrays(mask, data1, data2, data3)
+    assert np.array_equal(out1b, expected1)
+    assert np.array_equal(out2b, expected2)
+    assert np.array_equal(out3b, expected3)
+
 def test_get_range():
 
     data = np.array([0.5, 1., 1.5, 2., 2.5])

--- a/spiketools/utils/data.py
+++ b/spiketools/utils/data.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from scipy.ndimage import gaussian_filter
 
+from spiketools.utils.extract import create_nan_mask
 from spiketools.utils.checks import check_array_orientation, check_param_options, check_bin_range
 
 ###################################################################################################
@@ -128,12 +129,12 @@ def drop_nans(data):
     array([1. , 2. , 3.5, 6. , 2. , 1. ])
     """
 
-    nans = np.isnan(data)
+    mask = create_nan_mask(data)
 
     if data.ndim == 1:
-        data = data[np.where(~nans)]
+        data = data[mask]
     elif data.ndim == 2:
-        data = data[~nans].reshape(nans.shape[0], sum(~nans[0, :]))
+        data = data[mask].reshape(mask.shape[0], sum(mask[0, :]))
     else:
         raise ValueError('Only 1d or 2d arrays supported.')
 

--- a/spiketools/utils/epoch.py
+++ b/spiketools/utils/epoch.py
@@ -120,7 +120,7 @@ def epoch_spikes_by_segment(spikes, segments):
     return segment_spikes
 
 
-def epoch_data_by_time(timestamps, values, timepoints, threshold=None):
+def epoch_data_by_time(timestamps, values, timepoints, time_threshold=None):
     """Epoch data into trials, based on individual timepoints of interest.
 
     Parameters
@@ -131,7 +131,7 @@ def epoch_data_by_time(timestamps, values, timepoints, threshold=None):
         Data values.
     timepoints : list of float
         The time value(s), in seconds, to extract per trial.
-    threshold : float, optional
+    time_threshold : float, optional
         The threshold that the closest time value must be within to be returned.
         If the temporal distance is greater than the threshold, output is NaN.
 
@@ -153,7 +153,7 @@ def epoch_data_by_time(timestamps, values, timepoints, threshold=None):
 
     trials = [None] * len(timepoints)
     for ind, timepoint in enumerate(timepoints):
-        trials[ind] = get_value_by_time(timestamps, values, timepoint, threshold=threshold)
+        trials[ind] = get_value_by_time(timestamps, values, timepoint, time_threshold)
 
     return trials
 

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -397,6 +397,7 @@ def get_values_by_times(timestamps, values, timepoints, time_threshold=None,
     array([2, 4, 6])
     """
 
+    axis = check_axis(axis, values)
     inds = get_inds_by_times(timestamps, timepoints, time_threshold, drop_null)
 
     if drop_null:
@@ -404,9 +405,9 @@ def get_values_by_times(timestamps, values, timepoints, time_threshold=None,
     else:
         outputs = np.full([np.atleast_2d(values).shape[0], len(timepoints)], np.nan)
         mask = inds >= 0
-        outputs[:, np.where(mask)[0]] = values.take(indices=inds[mask],
-                                                    axis=check_axis(axis, values))
-        outputs = np.squeeze(outputs)
+        outputs[:, np.where(mask)[0]] = values.take(indices=inds[mask], axis=axis)
+        # Squeeze, with a special check for single value shape with needs an axis setting
+        outputs = np.squeeze(outputs, axis=0 if outputs.shape == (1, 1) else None)
 
     return outputs
 

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -215,7 +215,7 @@ def get_ind_by_value(values, value, threshold=None):
     return ind
 
 
-def get_ind_by_time(timestamps, timepoint, threshold=None):
+def get_ind_by_time(timestamps, timepoint, time_threshold=None):
     """Get the index for a set of timepoints closest to a specified timepoint.
 
     Parameters
@@ -224,7 +224,7 @@ def get_ind_by_time(timestamps, timepoint, threshold=None):
         Timestamps, in seconds.
     timepoint : float
         The time value to extract the index for.
-    threshold : float, optional
+    time_threshold : float, optional
         The threshold that the closest time value must be within to be returned.
         If the temporal distance is greater than the threshold, output is -1.
 
@@ -242,7 +242,7 @@ def get_ind_by_time(timestamps, timepoint, threshold=None):
     4
     """
 
-    return get_ind_by_value(timestamps, timepoint, threshold)
+    return get_ind_by_value(timestamps, timepoint, time_threshold)
 
 
 def get_inds_by_values(values, select, threshold=None, drop_null=True):
@@ -286,7 +286,7 @@ def get_inds_by_values(values, select, threshold=None, drop_null=True):
     return inds
 
 
-def get_inds_by_times(timestamps, timepoints, threshold=None, drop_null=True):
+def get_inds_by_times(timestamps, timepoints, time_threshold=None, drop_null=True):
     """Get indices for a set of specified time points.
 
     Parameters
@@ -295,7 +295,7 @@ def get_inds_by_times(timestamps, timepoints, threshold=None, drop_null=True):
         Timestamps, in seconds.
     timepoints : 1d array
         The time values, in seconds, to extract indices for.
-    threshold : float, optional
+    time_threshold : float, optional
         The threshold that the closest time value must be within to be returned.
         If the temporal distance is greater than the threshold, output is -1.
     drop_null : bool, optional, default: True
@@ -317,10 +317,10 @@ def get_inds_by_times(timestamps, timepoints, threshold=None, drop_null=True):
     array([1, 3, 5])
     """
 
-    return get_inds_by_values(timestamps, timepoints, threshold, drop_null)
+    return get_inds_by_values(timestamps, timepoints, time_threshold, drop_null)
 
 
-def get_value_by_time(timestamps, values, timepoint, threshold=None, axis=None):
+def get_value_by_time(timestamps, values, timepoint, time_threshold=None, axis=None):
     """Get the value from a data array at a specific time point.
 
     Parameters
@@ -331,7 +331,7 @@ def get_value_by_time(timestamps, values, timepoint, threshold=None, axis=None):
         Data values, corresponding to the time values in `timestamps`.
     timepoint : float
         Time value to extract.
-    threshold : float, optional
+    time_threshold : float, optional
         The threshold that the closest time value must be within to be returned.
         If the temporal distance is greater than the threshold, output is -1.
     axis : {0, 1}, optional
@@ -353,13 +353,14 @@ def get_value_by_time(timestamps, values, timepoint, threshold=None, axis=None):
     array([3, 9])
     """
 
-    idx = get_ind_by_time(timestamps, timepoint, threshold=threshold)
+    idx = get_ind_by_time(timestamps, timepoint, time_threshold=time_threshold)
     out = values.take(indices=idx, axis=check_axis(axis, values)) if idx >= 0 else np.nan
 
     return out
 
 
-def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_null=True, axis=None):
+def get_values_by_times(timestamps, values, timepoints, time_threshold=None,
+                        drop_null=True, axis=None):
     """Get values from a data array for a set of specified time points.
 
     Parameters
@@ -370,7 +371,7 @@ def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_nul
         Data values, corresponding to the time values in `timestamps`.
     timepoints : 1d array
         The time values, in seconds, to extract corresponding values for.
-    threshold : float, optional
+    time_threshold : float, optional
         The threshold that the closest time value must be within to be returned.
         If the temporal distance is greater than the threshold, output is NaN.
     drop_null : bool, optional, default: True
@@ -396,7 +397,7 @@ def get_values_by_times(timestamps, values, timepoints, threshold=None, drop_nul
     array([2, 4, 6])
     """
 
-    inds = get_inds_by_times(timestamps, timepoints, threshold, drop_null)
+    inds = get_inds_by_times(timestamps, timepoints, time_threshold, drop_null)
 
     if drop_null:
         outputs = values.take(indices=inds, axis=check_axis(axis, values))
@@ -448,7 +449,7 @@ def get_values_by_time_range(timestamps, values, t_min, t_max, axis=None):
     return timestamps[select], out
 
 
-def threshold_spikes_by_times(spikes, timestamps, threshold):
+def threshold_spikes_by_times(spikes, timestamps, time_threshold):
     """Threshold spikes by sub-selecting those that are temporally close to a set of time values.
 
     Parameters
@@ -457,9 +458,9 @@ def threshold_spikes_by_times(spikes, timestamps, threshold):
         Spike times, in seconds.
     timestamps : 1d array
         Timestamps, in seconds.
-    threshold : float
-        The threshold value for the time between the spike and a timestamp for the spike to be kept.
-        Any spikes further in time from a timestamp value are dropped.
+    time_threshold : float, optional
+        The threshold that the closest time value must be to a spike for it to be returned.
+        If the temporal distance is greater than the threshold, spike is dropped.
 
     Returns
     -------
@@ -472,13 +473,13 @@ def threshold_spikes_by_times(spikes, timestamps, threshold):
 
     >>> spikes = np.array([0.76, 1.12, 1.72, 2.05, 2.32, 2.92, 3.11, 3.63, 3.91])
     >>> timestamps = np.array([1.0, 1.25, 1.5, 1.75, 2.0, 3.5, 3.75, 4.0])
-    >>> threshold_spikes_by_times(spikes, timestamps, threshold=0.25)
+    >>> threshold_spikes_by_times(spikes, timestamps, time_threshold=0.25)
     array([0.76, 1.12, 1.72, 2.05, 3.63, 3.91])
     """
 
     mask = np.empty_like(spikes, dtype=bool)
     for ind, spike in enumerate(spikes):
-        mask[ind] = np.min(np.abs(timestamps - spike)) < threshold
+        mask[ind] = np.min(np.abs(timestamps - spike)) < time_threshold
 
     return spikes[mask]
 

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -511,11 +511,11 @@ def threshold_spikes_by_values(spikes, timestamps, values, min_value=None,
     --------
     Threshold spikes based on a minimum data threshold:
 
-    >>> spikes = np.array([0.1, 0.3, 0.4, 0.5, 1, 1.2, 1.6, 1.8])
-    >>> timestamps = np.array([0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4])
-    >>> values = np.array([1, 2, 3, 4, 5, 6, 7, 8])
-    >>> threshold_spikes_by_values(spikes, timestamps, values, 2)
-    array([1.6, 1.8])
+    >>> spikes = np.array([0.1, 0.4, 1.2, 1.6, 1.8, 2.5, 2.9])
+    >>> timestamps = np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
+    >>> values = np.array([1.0, 2.0, 3.0, 2.0, 3.0, 2.0])
+    >>> threshold_spikes_by_values(spikes, timestamps, values, min_value=2.5)
+    array([1.6, 2.5])
     """
 
     values = get_values_by_times(timestamps, values, spikes, time_threshold, drop_null=False)

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -3,7 +3,6 @@
 import numpy as np
 
 from spiketools.utils.checks import check_axis, check_param_type
-from spiketools.utils.options import get_comp_func
 
 ###################################################################################################
 ###################################################################################################
@@ -441,8 +440,8 @@ def threshold_spikes_by_times(spikes, timestamps, threshold):
     return spikes[mask]
 
 
-def threshold_spikes_by_values(spikes, timestamps, values, data_threshold,
-                               time_threshold=None, data_comparison='greater'):
+def threshold_spikes_by_values(spikes, timestamps, values, min_value=None,
+                               max_value=None,time_threshold=None):
     """Threshold spikes by sub-selecting based on thresholding values on another data stream.
 
     Parameters
@@ -453,14 +452,12 @@ def threshold_spikes_by_values(spikes, timestamps, values, data_threshold,
         Timestamps, in seconds.
     values : 1d array
         Data values, corresponding to the timestamps.
-    data_threshold : float
-        The threshold for the data, used to select spikes based on data values
+    min_value, max_value : float, optional
+        Minimum and/or maximum threshold value to select spikes based on.
+        The minimum value is inclusive, but the maximum value is exclusive.
     time_threshold : float, optional
         The threshold value for the time between the spike and a timestamp for the spike to be kept.
         Any spikes further in time from a timestamp value are dropped.
-    data_comparison : {'greater', 'less'}
-        Which comparison function to use for the data threshold.
-        This defines whether selected values must be greater than or less than the data threshold.
 
     Returns
     -------
@@ -482,7 +479,8 @@ def threshold_spikes_by_values(spikes, timestamps, values, data_threshold,
 
     mask = ~np.isnan(values)
     spikes, values = spikes[mask], values[mask]
-    spikes = spikes[get_comp_func(data_comparison)(values, data_threshold)]
+
+    spikes = spikes[create_mask(values, min_value, max_value)]
 
     return spikes
 

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -484,7 +484,7 @@ def threshold_spikes_by_times(spikes, timestamps, threshold):
 
 
 def threshold_spikes_by_values(spikes, timestamps, values, min_value=None,
-                               max_value=None,time_threshold=None):
+                               max_value=None, time_threshold=None):
     """Threshold spikes by sub-selecting based on thresholding values on another data stream.
 
     Parameters


### PR DESCRIPTION
In #185 we updated how the different thresholds get used when computing occupancy. 

What I forgot to do / check was to do the analogous updates for computing place bins (the neural part), meaning that currently defining behavioural occupancy and place-related neural firing could be different. 

This PR updates place computations to use thresholds consistent to occupancy. In doing so, it also does some updates and additions to related utils. 