### PR TITLE
[ENH] - Extend trial plotting

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -418,6 +418,7 @@ Plots for trial-epoched data.
 
    plot_rasters
    plot_rate_by_time
+   plot_raster_and_rates
    create_raster_title
 
 Stats

--- a/spiketools/plts/trials.py
+++ b/spiketools/plts/trials.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from spiketools.utils.base import flatten
+from spiketools.utils.trials import extract_conditions_dict
 from spiketools.utils.options import get_avg_func, get_var_func
 from spiketools.plts.settings import DEFAULT_COLORS
 from spiketools.plts.annotate import add_vlines, add_vshades, add_significance
@@ -46,12 +47,8 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
     custom_kwargs = ['line_color', 'line_lw', 'line_alpha', 'shade_color', 'shade_alpha']
     custom_plt_kwargs = get_kwargs(plt_kwargs, custom_kwargs)
 
-    if isinstance(spikes, dict):
-        spike_keys = list(spikes.keys())
-        spikes = list(spikes.values())
-        if isinstance(colors, dict):
-            assert list(colors.keys()) == spike_keys, 'Colors do not match condition labels.'
-            colors = list(colors.values())
+    # Check and unpack condition data, if provided as a dictionary input
+    spikes, colors = extract_conditions_dict(spikes, colors)
 
     # This process infers whether there is are embedded lists of multiple conditions
     check = False
@@ -133,12 +130,8 @@ def plot_rate_by_time(bin_times, trial_cfrs, average=None, shade=None, vline=Non
     custom_kwargs = ['shade_alpha', 'legend_loc','line_color', 'line_lw', 'line_alpha']
     custom_plt_kwargs = get_kwargs(plt_kwargs, custom_kwargs)
 
-    if isinstance(trial_cfrs, dict):
-        cfrs_keys = list(trial_cfrs.keys())
-        trial_cfrs = list(trial_cfrs.values())
-        if isinstance(colors, dict):
-            assert list(colors.keys()) == cfrs_keys, 'Colors do not match condition labels.'
-            colors = list(colors.values())
+    # Check and unpack condition data, if provided as a dictionary input
+    trial_cfrs, colors = extract_conditions_dict(trial_cfrs, colors)
 
     # If not a list of arrays, embed in a list to allow for looping (to support multiple inputs)
     if not isinstance(trial_cfrs[0], np.ndarray):

--- a/spiketools/plts/trials.py
+++ b/spiketools/plts/trials.py
@@ -20,14 +20,15 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
 
     Parameters
     ----------
-    spikes : list of list of float
+    spikes : list of list of float or dict
         Spike times per trial.
-        Multiple conditions can also be passed in.
+        Multiple conditions can also be passed in, as dictionary key labels and spike values.
     vline : float or list of float, optional
         Location(s) to draw a vertical line. If None, no line is drawn.
-    colors : str or list of str, optional
+    colors : str or list of str or dict, optional
         Color(s) to plot the raster ticks.
         If more than one, should match the number of conditions.
+        If a dictionary, the labels should match the spike condition labels.
     vshade : list of float or list of list of float, optional
         Vertical region(s) of the plot to shade in.
     show_axis : bool, optional, default: False
@@ -43,6 +44,13 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
 
     custom_kwargs = ['line_color', 'line_lw', 'line_alpha', 'shade_color', 'shade_alpha']
     custom_plt_kwargs = get_kwargs(plt_kwargs, custom_kwargs)
+
+    if isinstance(spikes, dict):
+        spike_keys = list(spikes.keys())
+        spikes = list(spikes.values())
+        if isinstance(colors, dict):
+            assert list(colors.keys()) == spike_keys, 'Colors do not match spike labels.'
+            colors = list(colors.values())
 
     # This process infers whether there is are embedded lists of multiple conditions
     check = False

--- a/spiketools/plts/trials.py
+++ b/spiketools/plts/trials.py
@@ -234,7 +234,8 @@ def plot_raster_and_rates(spikes, bins, time_range, conditions=None, colors=None
 
     plot_rate_by_time(tbins, trial_frs, average='mean', shade='sem',
                       **rate_kwargs, colors=colors, ax=axes[1])
-    axes[1].spines[['right', 'top']].set_visible(False)
+    for side in ['right', 'top']:
+        axes[1].spines[side].set_visible(False)
 
     # Add vertical line across axes
     line_kwargs = {

--- a/spiketools/plts/trials.py
+++ b/spiketools/plts/trials.py
@@ -22,7 +22,8 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
     ----------
     spikes : list of list of float or dict
         Spike times per trial.
-        Multiple conditions can also be passed in, as dictionary key labels and spike values.
+        Multiple conditions can also be passed in.
+        If dict, each key is a condition label and each value the list of list of spikes times.
     vline : float or list of float, optional
         Location(s) to draw a vertical line. If None, no line is drawn.
     colors : str or list of str or dict, optional
@@ -49,7 +50,7 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
         spike_keys = list(spikes.keys())
         spikes = list(spikes.values())
         if isinstance(colors, dict):
-            assert list(colors.keys()) == spike_keys, 'Colors do not match spike labels.'
+            assert list(colors.keys()) == spike_keys, 'Colors do not match condition labels.'
             colors = list(colors.values())
 
     # This process infers whether there is are embedded lists of multiple conditions
@@ -98,19 +99,21 @@ def plot_rate_by_time(bin_times, trial_cfrs, average=None, shade=None, vline=Non
     ----------
     bin_times : 1d array
         Values of the time bins, to be plotted on the x-axis.
-    trial_cfrs : list of array
+    trial_cfrs : list of array or dict
         Continuous firing rate values, to be plotted on the y-axis.
         If each array is 1d values are plotted directly.
         If 2d, is to be averaged before plotting.
+        If dict, each key is a condition label and each value the array of firing rates.
     average : {'mean', 'median'}, optional
         Averaging to apply to firing rate activity before plotting.
     shade : {'sem', 'std'} or list of array, optional
         Measure of variance to compute and/or plot as shading.
     vline : float or list of float, optional
         Location(s) to draw a vertical line. If None, no line is drawn.
-    colors : str or list of str, optional
+    colors : str or list of str or dict, optional
         Color(s) to plot the firing rates.
         If more than one, should match the number of conditions.
+        If a dictionary, the labels should match the spike condition labels.
     labels : list of str, optional
         Labels for each set of y-values.
         If provided, a legend is added to the plot.
@@ -129,6 +132,13 @@ def plot_rate_by_time(bin_times, trial_cfrs, average=None, shade=None, vline=Non
 
     custom_kwargs = ['shade_alpha', 'legend_loc','line_color', 'line_lw', 'line_alpha']
     custom_plt_kwargs = get_kwargs(plt_kwargs, custom_kwargs)
+
+    if isinstance(trial_cfrs, dict):
+        cfrs_keys = list(trial_cfrs.keys())
+        trial_cfrs = list(trial_cfrs.values())
+        if isinstance(colors, dict):
+            assert list(colors.keys()) == cfrs_keys, 'Colors do not match condition labels.'
+            colors = list(colors.values())
 
     # If not a list of arrays, embed in a list to allow for looping (to support multiple inputs)
     if not isinstance(trial_cfrs[0], np.ndarray):
@@ -170,6 +180,8 @@ def plot_rate_by_time(bin_times, trial_cfrs, average=None, shade=None, vline=Non
     if stats:
         add_significance(stats, sig_level=sig_level, ax=ax)
 
+
+## Trial plot utilities
 
 def create_raster_title(label, avg_pre, avg_post, t_val=None, p_val=None):
     """Create a standardized title for an event-related raster plot.

--- a/spiketools/plts/trials.py
+++ b/spiketools/plts/trials.py
@@ -17,7 +17,7 @@ from spiketools.plts.style import set_plt_kwargs
 
 @savefig
 @set_plt_kwargs
-def plot_rasters(spikes, vline=None, colors=None, vshade=None,
+def plot_rasters(spikes, events=None, vline=None, colors=None, vshade=None,
                  show_axis=False, ax=None, **plt_kwargs):
     """Plot rasters across multiple trials.
 
@@ -27,6 +27,8 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
         Spike times per trial.
         Multiple conditions can also be passed in.
         If dict, each key is a condition label and each value the list of list of spikes times.
+    events : list
+        Events to indicate on the raster plot. Should have length of number of trials.
     vline : float or list of float, optional
         Location(s) to draw a vertical line. If None, no line is drawn.
     colors : str or list of str or dict, optional
@@ -41,12 +43,17 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
         Axis object upon which to plot.
     plt_kwargs
         Additional arguments to pass into the plot function.
-        Custom kwargs: 'line_color', 'line_lw', 'line_alpha', 'shade_color', 'shade_alpha'.
+        Custom kwargs:
+            line: 'line_color', 'line_lw', 'line_alpha'
+            shade: 'shade_color', 'shade_alpha'
+            events: 'event_color', 'event_linewidths', 'event_linelengths'
     """
 
     ax = check_ax(ax, figsize=plt_kwargs.pop('figsize', None))
 
-    custom_kwargs = ['line_color', 'line_lw', 'line_alpha', 'shade_color', 'shade_alpha']
+    custom_kwargs = ['line_color', 'line_lw', 'line_alpha',
+                     'shade_color', 'shade_alpha',
+                     'event_color', 'event_linewidths', 'event_linelengths']
     custom_plt_kwargs = get_kwargs(plt_kwargs, custom_kwargs)
 
     # Check and unpack condition data, if provided as a dictionary input
@@ -75,6 +82,15 @@ def plot_rasters(spikes, vline=None, colors=None, vshade=None,
         spikes = flatten(spikes)
 
     ax.eventplot(spikes, colors=colors, **plt_kwargs)
+
+    # If provided, add events to plot
+    if events is not None:
+        if isinstance(events[0], float):
+            events = [[el] for el in events]
+        ax.eventplot(events,
+                     color=custom_plt_kwargs.pop('event_color', 'red'),
+                     linelengths=custom_plt_kwargs.pop('event_linelengths', 1.25),
+                     linewidths=custom_plt_kwargs.pop('event_linewidths', 3));
 
     add_vlines(vline, ax, zorder=0,
                color=custom_plt_kwargs.pop('line_color', 'green'),

--- a/spiketools/plts/utils.py
+++ b/spiketools/plts/utils.py
@@ -180,7 +180,8 @@ def make_axes(n_axes, n_cols=5, figsize=None, row_size=4, col_size=3.6,
 
     if title:
         plt.suptitle(title,
-                     fontsize=title_kwargs.pop('title_fontsize', 24),
+                     fontsize=title_kwargs.pop('fontsize', 24),
+                     y=title_kwargs.pop('y', 0.95),
                      **title_kwargs)
 
     return axes.flatten()
@@ -206,8 +207,8 @@ def make_grid(nrows, ncols, title=None, **plt_kwargs):
 
     if title:
         plt.suptitle(title,
-                     fontsize=title_kwargs.pop('title_fontsize', 24),
-                     y=title_kwargs.pop('title_y', 0.95),
+                     fontsize=title_kwargs.pop('fontsize', 24),
+                     y=title_kwargs.pop('y', 0.95),
                      **title_kwargs)
 
     return grid

--- a/spiketools/tests/plts/test_trials.py
+++ b/spiketools/tests/plts/test_trials.py
@@ -13,17 +13,20 @@ from spiketools.plts.trials import *
 @plot_test
 def test_plot_rasters():
 
-    data0 = [-0.5, -0.25, 0.250, 1.0]
-    data1 = [[-0.75, -0.30, 0.125, 0.250, 0.750],
-             [-0.50, -0.40, -0.50, 0.10, 0.125, 0.50, 0.80],
-             [-0.85, -0.50, -0.25, 0.10, 0.40, 0.750, 0.950]]
-    data2 = [data1, [[-0.40, 0.15, 0.50], [-0.50, 0.25, 0.80]]]
+    d_one_trial = [-0.5, -0.25, 0.250, 1.0]
+    d_multi_trial1 = [[-0.75, -0.30, 0.125, 0.250, 0.750],
+                      [-0.50, -0.40, -0.50, 0.10, 0.125, 0.50, 0.80],
+                      [-0.85, -0.50, -0.25, 0.10, 0.40, 0.750, 0.950]]
+    d_multi_trial2 = [[-0.40, 0.15, 0.50],
+                      [-0.50, 0.25, 0.80]]
 
-    plot_rasters(data0, file_path=TEST_PLOTS_PATH, file_name='tplot_rasters0.png')
-    plot_rasters(data1, file_path=TEST_PLOTS_PATH, file_name='tplot_rasters1.png')
-    plot_rasters(data2, colors=['blue', 'red'],
+    plot_rasters(d_one_trial, file_path=TEST_PLOTS_PATH, file_name='tplot_rasters0.png')
+    plot_rasters(d_multi_trial1, file_path=TEST_PLOTS_PATH, file_name='tplot_rasters1.png')
+    plot_rasters([d_multi_trial1, d_multi_trial2], colors=['blue', 'red'],
                  file_path=TEST_PLOTS_PATH, file_name='tplot_rasters2.png')
-
+    plot_rasters({'d0' : d_multi_trial1, 'd1' : d_multi_trial2},
+                 colors={'d0' : 'blue', 'd1' : 'red'},
+                 file_path=TEST_PLOTS_PATH, file_name='tplot_rasters3.png')
 
 @plot_test
 def test_plot_rate_by_time():

--- a/spiketools/tests/plts/test_trials.py
+++ b/spiketools/tests/plts/test_trials.py
@@ -20,13 +20,20 @@ def test_plot_rasters():
     d_multi_trial2 = [[-0.40, 0.15, 0.50],
                       [-0.50, 0.25, 0.80]]
 
-    plot_rasters(d_one_trial, file_path=TEST_PLOTS_PATH, file_name='tplot_rasters0.png')
-    plot_rasters(d_multi_trial1, file_path=TEST_PLOTS_PATH, file_name='tplot_rasters1.png')
+    plot_rasters(d_one_trial,
+                 file_path=TEST_PLOTS_PATH, file_name='tplot_rasters0.png')
+    plot_rasters(d_multi_trial1,
+                 file_path=TEST_PLOTS_PATH, file_name='tplot_rasters1.png')
     plot_rasters([d_multi_trial1, d_multi_trial2], colors=['blue', 'red'],
                  file_path=TEST_PLOTS_PATH, file_name='tplot_rasters2.png')
     plot_rasters({'c0' : d_multi_trial1, 'c1' : d_multi_trial2},
                  colors={'c0' : 'blue', 'c1' : 'red'},
                  file_path=TEST_PLOTS_PATH, file_name='tplot_rasters3.png')
+    plot_rasters(d_multi_trial1, events=[0.5, 0.6, 0.4],
+                 file_path=TEST_PLOTS_PATH, file_name='tplot_rasters4.png')
+    plot_rasters([d_multi_trial1, d_multi_trial2],
+                 events=[[0.25, 0.5], [0.6], [0.4], [0.6], [0.5]],
+                 file_path=TEST_PLOTS_PATH, file_name='tplot_rasters5.png')
 
 @plot_test
 def test_plot_rate_by_time():

--- a/spiketools/tests/plts/test_trials.py
+++ b/spiketools/tests/plts/test_trials.py
@@ -47,6 +47,24 @@ def test_plot_rate_by_time():
                       colors = {'c0' : 'red', 'c1' : 'blue'},
                       file_path=TEST_PLOTS_PATH, file_name='tplot_time_rates3.png')
 
+
+def test_plot_raster_and_rates():
+
+    trial_spikes = [[-0.75, -0.30, 0.125, 0.250, 0.750],
+                    [-0.50, -0.40, -0.50, 0.10, 0.125, 0.50, 0.80],
+                    [-0.85, -0.50, -0.25, 0.10, 0.40, 0.750, 0.950],
+                    [-0.40, 0.15, 0.50],
+                    [-0.50, 0.25, 0.80]]
+    trial_spikes = [np.array(el) for el in trial_spikes]
+
+    plot_raster_and_rates(trial_spikes, 0.5, [-1, 1],
+                          file_path=TEST_PLOTS_PATH, file_name='tplot_raster_rates1.png')
+
+    plot_raster_and_rates(trial_spikes, 0.5, [-1, 1],
+                          conditions=['l', 'r', 'l', 'r', 'l'],
+                          colors={'l' : 'red', 'r' : 'blue'},
+                          file_path=TEST_PLOTS_PATH, file_name='tplot_raster_rates2.png')
+
 def test_create_raster_title():
 
     title1 = create_raster_title('label1', 1.0, 2.0)

--- a/spiketools/tests/plts/test_trials.py
+++ b/spiketools/tests/plts/test_trials.py
@@ -24,8 +24,8 @@ def test_plot_rasters():
     plot_rasters(d_multi_trial1, file_path=TEST_PLOTS_PATH, file_name='tplot_rasters1.png')
     plot_rasters([d_multi_trial1, d_multi_trial2], colors=['blue', 'red'],
                  file_path=TEST_PLOTS_PATH, file_name='tplot_rasters2.png')
-    plot_rasters({'d0' : d_multi_trial1, 'd1' : d_multi_trial2},
-                 colors={'d0' : 'blue', 'd1' : 'red'},
+    plot_rasters({'c0' : d_multi_trial1, 'c1' : d_multi_trial2},
+                 colors={'c0' : 'blue', 'c1' : 'red'},
                  file_path=TEST_PLOTS_PATH, file_name='tplot_rasters3.png')
 
 @plot_test
@@ -41,6 +41,11 @@ def test_plot_rate_by_time():
     plot_rate_by_time(x_vals, [y_vals1, y_vals2], average='median', shade='sem',
                       labels=['A', 'B'], stats=[0.5, 0.01, 0.5, 0.01, 0.5],
                       file_path=TEST_PLOTS_PATH, file_name='tplot_time_rates2.png')
+
+    plot_rate_by_time(x_vals, {'c0' : y_vals1, 'c1' : y_vals2},
+                      average='median', shade='sem',
+                      colors = {'c0' : 'red', 'c1' : 'blue'},
+                      file_path=TEST_PLOTS_PATH, file_name='tplot_time_rates3.png')
 
 def test_create_raster_title():
 

--- a/spiketools/tests/utils/test_trials.py
+++ b/spiketools/tests/utils/test_trials.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from pytest import raises
+
 from spiketools.utils.trials import *
 
 ###################################################################################################
@@ -68,3 +70,23 @@ def test_recombine_trial_data():
     times_missing, values_missing = recombine_trial_data(trial_times_missing, trial_values_missing)
     assert np.array_equal(times_missing, expected_times)
     assert np.array_equal(values_missing, np.array([10, 11, 12, 1, 2]))
+
+def test_extract_conditions_dict():
+
+    d0 = np.array([1, 2, 3, 4])
+    d1 = np.array([5, 6, 7, 8])
+    cond_dict = {'d0' : d0, 'd1' : d1}
+
+    out1, _ = extract_conditions_dict(cond_dict, None)
+    assert isinstance(out1, list)
+    assert np.array_equal(out1[0], d0)
+    assert np.array_equal(out1[1], d1)
+
+    colors = {'d0' : 'red', 'd1' : 'blue'}
+    out2, colors2 = extract_conditions_dict(cond_dict, colors)
+    assert isinstance(out2, list)
+    assert isinstance(colors2, list)
+    assert colors2 == list(colors.values())
+
+    with raises(AssertionError):
+        out3, colors3 = extract_conditions_dict(cond_dict, {'d1' : 'k', 'd2' : 'b'})

--- a/spiketools/utils/trials.py
+++ b/spiketools/utils/trials.py
@@ -117,3 +117,35 @@ def recombine_trial_data(times_trials, values_trials, axis=None):
     values = np.concatenate(values_trials, axis=check_axis(axis, values_trials[0]))
 
     return times, values
+
+
+def extract_conditions_dict(data, metadata=None):
+    """Extract a dictionary of data organized by condition into a list condition data.
+
+    Parameters
+    ----------
+    data : dict or object
+        A dictionary of
+        If not a dictionary, is returned as is.
+    metadata : dict or object
+        Dictionary of related metadata for the conditions.
+        If a dictonary, should have the same labels as `data`.
+        If not a dictionary, is returned as is.
+
+    Returns
+    -------
+    data : list
+        Extracted condition data.
+    metadata : list
+        Extracted condition metadata.
+        Only extracted if metadata input is not None.
+    """
+
+    if isinstance(data, dict):
+        labels = list(data.keys())
+        data = list(data.values())
+        if isinstance(metadata, dict):
+            assert list(metadata.keys()) == labels, 'Condition labels do not match.'
+            metadata = list(metadata.values())
+
+    return data, metadata

--- a/spiketools/utils/trials.py
+++ b/spiketools/utils/trials.py
@@ -145,7 +145,9 @@ def extract_conditions_dict(data, metadata=None):
         labels = list(data.keys())
         data = list(data.values())
         if isinstance(metadata, dict):
-            assert list(metadata.keys()) == labels, 'Condition labels do not match.'
+            assert set(labels) == set(metadata.keys()), 'Condition labels do not match.'
+            # This sorts the metadata dictionary to ensure it matches order of the data
+            metadata = dict(sorted(metadata.items(), key=lambda items: labels.index(items[0])))
             metadata = list(metadata.values())
 
     return data, metadata


### PR DESCRIPTION
This extends trial related plotting functionality, most notably:
- allow `plot_rasters` and `plot_rate_by_time` to accept dictionary input (convenient for multiple conditions)
- add new `plot_raster_and_rates` to plot a multi-axis, aligned plot of the raster and continuous firing rates

An example of the `plot_raster_and_rates` looks like this:
![Screen Shot 2024-06-07 at 2 07 00 PM](https://github.com/spiketools/spiketools/assets/7727566/b71d0339-034c-42e2-96d1-42d6c23b08e4)
