### PR TITLE
[WIP] - Update doctests for change in numpy

### DIFF
--- a/spiketools/measures/collections.py
+++ b/spiketools/measures/collections.py
@@ -34,7 +34,7 @@ def detect_empty_time_ranges(all_spikes, bins, time_range=None):
 
     >>> all_spikes = [np.array([0.25, 0.80, 1.25, 1.75, 4.15, 4.95]),
     ...               np.array([0.15, 0.55, 1.55, 1.95, 4.35, 4.85])]
-    >>> detect_empty_time_ranges(all_spikes, bins=1, time_range=[0, 5])
+    >>> detect_empty_time_ranges(all_spikes, bins=1, time_range=[0, 5])    # doctest: +SKIP
     [[2, 4]]
     """
 

--- a/spiketools/measures/spikes.py
+++ b/spiketools/measures/spikes.py
@@ -28,7 +28,7 @@ def compute_firing_rate(spikes, time_range=None):
     Compute spike rate from spike times:
 
     >>> spikes = np.array([0.5, 1, 1.5, 2, 2.5, 3])
-    >>> compute_firing_rate(spikes)
+    >>> float(compute_firing_rate(spikes))
     2.4
     """
 
@@ -86,7 +86,7 @@ def compute_cv(isis):
     Compute the coefficient of variation from interval-spike intervals:
 
     >>> isis = [0.3, 0.6, 0.6, 0.2, 0.7]
-    >>> compute_cv(isis)
+    >>> float(compute_cv(isis))
     0.4039733214513607
     """
 
@@ -111,7 +111,7 @@ def compute_fano_factor(spike_train):
     Compute the fano factor from a spike train:
 
     >>> spike_train = [0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 0]
-    >>> compute_fano_factor(spike_train)
+    >>> float(compute_fano_factor(spike_train))
     0.5
     """
 
@@ -182,7 +182,7 @@ def compute_presence_ratio(spikes, bins, time_range=None):
     Compute the presence ratio from spike times:
 
     >>> spikes = np.array([0.25, 1.15, 1.75, 2.25, 2.75, 4.5])
-    >>> compute_presence_ratio(spikes, bins=1, time_range=[0, 5])
+    >>> float(compute_presence_ratio(spikes, bins=1, time_range=[0, 5]))
     0.8
     """
 

--- a/spiketools/measures/trials.py
+++ b/spiketools/measures/trials.py
@@ -46,7 +46,7 @@ def compute_trial_frs(trial_spikes, bins, time_range=None, smooth=None):
     >>> bins = 0.5
     >>> time_range = [0.0, 1.0]
     >>> bin_times, trial_cfrs = compute_trial_frs(trial_spikes, bins, time_range)
-    >>> trial_cfrs
+    >>> trial_cfrs    # doctest: +SKIP
     array([[6., 0.],
            [8., 2.],
            [4., 4.]])
@@ -85,7 +85,7 @@ def compute_pre_post_rates(trial_spikes, pre_window, post_window):
     ...                 np.array([-0.250, 0.275, 0.290, 0.3, 0.350, 0.6]),
     ...                 np.array([0.550, 0.650, 0.70, 0.9, 0.950])]
     >>> pre_window, post_window = [-0.5, 0.0], [0.5, 0.9]
-    >>> compute_pre_post_rates(trial_spikes, pre_window, post_window)
+    >>> compute_pre_post_rates(trial_spikes, pre_window, post_window)    # doctest: +SKIP
     (array([6., 2., 0.]), array([2.5, 2.5, 7.5]))
     """
 
@@ -158,7 +158,7 @@ def compute_pre_post_averages(frs_pre, frs_post, avg_type='mean'):
 
     >>> frs_pre = np.array([5, 3, 1])
     >>> frs_post = np.array([12, 8, 10])
-    >>> compute_pre_post_averages(frs_pre, frs_post, avg_type='mean')
+    >>> compute_pre_post_averages(frs_pre, frs_post, avg_type='mean')    # doctest: +SKIP
     (3.0, 10.0)
     """
 
@@ -193,7 +193,7 @@ def compute_pre_post_diffs(frs_pre, frs_post, average=True, avg_type='mean'):
 
     >>> frs_pre = np.array([5, 3, 1])
     >>> frs_post = np.array([12, 8, 10])
-    >>> compute_pre_post_diffs(frs_pre, frs_post, average=True, avg_type='mean')
+    >>> float(compute_pre_post_diffs(frs_pre, frs_post, average=True, avg_type='mean'))
     7.0
     """
 

--- a/spiketools/measures/trials.py
+++ b/spiketools/measures/trials.py
@@ -46,7 +46,7 @@ def compute_trial_frs(trial_spikes, bins, time_range=None, smooth=None):
     >>> bins = 0.5
     >>> time_range = [0.0, 1.0]
     >>> bin_times, trial_cfrs = compute_trial_frs(trial_spikes, bins, time_range)
-    >>> trial_cfrs    # doctest: +SKIP
+    >>> trial_cfrs
     array([[6., 0.],
            [8., 2.],
            [4., 4.]])
@@ -85,7 +85,7 @@ def compute_pre_post_rates(trial_spikes, pre_window, post_window):
     ...                 np.array([-0.250, 0.275, 0.290, 0.3, 0.350, 0.6]),
     ...                 np.array([0.550, 0.650, 0.70, 0.9, 0.950])]
     >>> pre_window, post_window = [-0.5, 0.0], [0.5, 0.9]
-    >>> compute_pre_post_rates(trial_spikes, pre_window, post_window)    # doctest: +SKIP
+    >>> compute_pre_post_rates(trial_spikes, pre_window, post_window)
     (array([6., 2., 0.]), array([2.5, 2.5, 7.5]))
     """
 

--- a/spiketools/spatial/distance.py
+++ b/spiketools/spatial/distance.py
@@ -34,7 +34,7 @@ def compute_distance(p1, p2):
 
     >>> p1 = [1, 6]
     >>> p2 = [5, 9]
-    >>> compute_distance(p1, p2)
+    >>> float(compute_distance(p1, p2))
     5.0
     """
 
@@ -206,7 +206,7 @@ def get_closest_position(position, location, threshold=None):
 
     distances = compute_distances_to_location(position, location)
 
-    min_ind = np.argmin(distances)
+    min_ind = int(np.argmin(distances))
 
     if threshold:
         if distances[min_ind] > threshold:

--- a/spiketools/spatial/distance.py
+++ b/spiketools/spatial/distance.py
@@ -27,7 +27,7 @@ def compute_distance(p1, p2):
     Compute distance between two 1d positions:
 
     >>> p1, p2 = [2], [5]
-    >>> compute_distance(p1, p2)
+    >>> float(compute_distance(p1, p2))
     3.0
 
     Compute distance between the two 2d positions:

--- a/spiketools/spatial/utils.py
+++ b/spiketools/spatial/utils.py
@@ -132,7 +132,7 @@ def compute_bin_width(bin_edges):
     Compute bin width from an array of 5 bin edges:
 
     >>> bin_edges = [1.5, 3.5, 5.5, 7.5, 9.5]
-    >>> compute_bin_width(bin_edges)
+    >>> float(compute_bin_width(bin_edges))
     2.0
     """
 

--- a/spiketools/stats/anova.py
+++ b/spiketools/stats/anova.py
@@ -170,7 +170,7 @@ def fit_anova(df, formula, feature=None, return_type='f_val', anova_type=2):
     >>> df = create_dataframe_bins(data)
     >>> formula = 'fr ~ C(bin)'
     >>> f_val = fit_anova(df, formula, feature='C(bin)', return_type='f_val', anova_type=1)
-    >>> round(f_val, 4)
+    >>> float(round(f_val, 4))
     0.4249
     """
 

--- a/spiketools/stats/trials.py
+++ b/spiketools/stats/trials.py
@@ -29,7 +29,7 @@ def compute_pre_post_ttest(frs_pre, frs_post):
 
     >>> frs_pre = np.array([1.5, 1.8, 1.9, 2.0, 2.2])
     >>> frs_post = np.array([5.5, 6.5, 6.6, 6.7, 7.1])
-    >>> compute_pre_post_ttest(frs_pre, frs_post)
+    >>> compute_pre_post_ttest(frs_pre, frs_post)    # doctest: +SKIP
     (-29.692872320923538, 7.660650245217322e-06)
     """
 
@@ -65,7 +65,8 @@ def compare_pre_post_activity(trial_spikes, pre_window, post_window, avg_type='m
     ...                 np.array([-0.15, 0.45, 1.0, 1.2, 1.6]),
     ...                 np.array([-0.45, -0.12, -0.02, 0.32, 0.67, 0.89, 1.7])]
     >>> pre_window, post_window = [-0.5, 0], [0, 2]
-    >>> compare_pre_post_activity(trial_spikes, pre_window, post_window, avg_type='mean')
+    >>> compare_pre_post_activity(\                                         # doctest: +SKIP
+    ...     trial_spikes, pre_window, post_window, avg_type='mean')
     (4.0, 2.0, 1.7320508075688774, 0.22540333075851657)
     """
 

--- a/spiketools/utils/data.py
+++ b/spiketools/utils/data.py
@@ -59,7 +59,7 @@ def compute_range(data):
     Compute the range of some position data:
 
     >>> data = np.array([1.5, 1, 0.5, 2, 3, 2.5])
-    >>> compute_range(data)
+    >>> compute_range(data)    # doctest: +SKIP
     (0.5, 3.0)
     """
 

--- a/spiketools/utils/epoch.py
+++ b/spiketools/utils/epoch.py
@@ -147,7 +147,7 @@ def epoch_data_by_time(timestamps, values, timepoints, time_threshold=None):
     >>> timestamps = np.array([0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5])
     >>> values = np.array([1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5])
     >>> timepoints = [0.3, 0.7, 1.3]
-    >>> epoch_data_by_time(timestamps, values, timepoints)
+    >>> epoch_data_by_time(timestamps, values, timepoints)    # doctest: +SKIP
     [1.5, 2.5, 4.0]
     """
 

--- a/spiketools/utils/extract.py
+++ b/spiketools/utils/extract.py
@@ -206,7 +206,7 @@ def get_ind_by_value(values, value, threshold=None):
     check_param_type(value, 'value', (int, float, np.int64, np.float64))
     assert not np.isnan(value), "The given `value` is nan - cannot continue."
 
-    ind = np.abs(values - value).argmin()
+    ind = int(np.abs(values - value).argmin())
 
     if threshold:
         if np.abs(values[ind] - value) > threshold:


### PR DESCRIPTION
There is a change in numpy >= 2.0 in how values are printed out (it now prints the type). This creates some issues with doctests (e.g. expected value 1.0 is now expected value np.float64(1.0)). 

There does not seem to be a clear way to address this, that works across numpy 1.X and 2.X. For now at least, this PR adds some adhoc fixes - typecasting some values to fix it up, and turning some doctest checks off. 