### PR TITLE
[MNT] - Update handling of default colors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-# Note: tag pandas below 3 while are some quirks with access numpy arrays
+# Note: tag pandas below 3 while are some quirks with accessing numpy arrays
 pandas < 3.0.0
 scipy
 matplotlib

--- a/spiketools/plts/settings.py
+++ b/spiketools/plts/settings.py
@@ -1,6 +1,7 @@
 """Default settings for plots."""
 
 import matplotlib.pyplot as plt
+from matplotlib.colors import to_hex
 
 ###################################################################################################
 ###################################################################################################
@@ -12,8 +13,10 @@ SET_KWARGS = ['title', 'xlim', 'ylim', 'xlabel', 'ylabel',
 # Define a list of other arguments to be caught
 OTHER_KWARGS = ['legend']
 
-# Collect a list of the default matplotlib color cycle
-DEFAULT_COLORS = plt.rcParams['axes.prop_cycle'].by_key()['color']
+# Define list of default plot colors, making sure colors are hex, for downstream consistency
+#   Hex encoding changed in mpl: https://github.com/matplotlib/matplotlib/issues/29915
+DEFAULT_COLORS = [to_hex(col) for col in plt.rcParams['axes.prop_cycle'].by_key()['color']] \
+    if plt else None
 
 # Define default settings for plotting text
 TEXT_SETTINGS = {'fontdict' : {'fontsize' : 14}, 'ha' : 'center', 'va' : 'center'}


### PR DESCRIPTION
This updates handling of getting default colors from matplotlib - as the behaviour there changed (returning ([rgba], ...) instead of hex, which led to downstream errors on our side (see: https://github.com/matplotlib/matplotlib/issues/29915).

This explicitly casts accessed default color cycle to hex to maintain consistency on our side.